### PR TITLE
`frontend-ui-config` support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
-WEBGUI_TAG=latest-master
 SOCIAL_WEB_APP_TAG=latest
 SERVICE_PROCESSING_TAG=latest

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,9 +1,6 @@
 version: "3.3"
 
 services:
-  webgui:
-    image: pacefactory/safety-gui2-js:${WEBGUI_TAG:-latest-master}
-
   social_web_app:
     image: pacefactory/social_web_app:${SOCIAL_WEB_APP_TAG:-latest}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,15 +65,18 @@ services:
 
   webgui:
     container_name: webgui
-    image: pacefactory/safety-gui2-js:latest-master
+    # TODO: Revert to latest-master upon merge into main
+    image: pacefactory/safety-gui2-js:frontend-ui-config
     hostname: webgui
     restart: always
     depends_on:
       - dbserver
-    environment:
-      - "REACT_APP_DB_HOST=dbserver"
+      - service_gifwrapper
+      - service_dtreeserver
     ports:
       - "81:80"
+    volumes:
+      - "webgui-data:/home/scv2/volume"
     networks:
       - external_network
 
@@ -169,6 +172,7 @@ volumes:
   service_classifier-data:
   social_video_server-data:
   relational_dbserver-data:
+  webgui-data:
 
 networks:
   internal_network:


### PR DESCRIPTION
Once we've completed the switch over to `frontend-ui-config` on the webgui at all sites, we will want to merge this into main.

This will act as a staging branch in the interim until we have all sites ready to switch.

Fixes #8 

