### PR TITLE
Add APE profile

### DIFF
--- a/compose/docker-compose.ape.yml
+++ b/compose/docker-compose.ape.yml
@@ -1,0 +1,30 @@
+x-pf-info:
+  name: APE profile
+  prompt: Enable the Alert Processing Engine (APE) profile?
+  description: The Alert Processing Engine produces realtime alerts from MQTT object data.
+  settings:
+    APE_TAG:
+      default: latest
+
+services:
+  alert_processing_engine:
+    container_name: ${PROJECT_PREFIX:-}alert_processing_engine
+    hostname: ${PROJECT_PREFIX:-}alert_processing_engine
+    image: pacefactory/alert_processing_engine:${APE_TAG:-latest}
+    restart: always
+    logging:
+      driver: local
+    depends_on:
+      - pf_mosquitto
+    # Volume is used for storing JSON configs - if those configs are eventually
+    # moved somewhere else, this volume can be removed.
+    volumes:
+      - "ape-data:/home/scv2/ape"
+    networks:
+      - external_network
+    environment:
+      - "PF_MQTT_URL=mqtt://admin:pfadminpw@${PROJECT_PREFIX:-}pf_mosquitto:1883"
+      - "PF_APE_CONFIG_DIR=/home/scv2/ape"
+
+volumes:
+  ape-data:


### PR DESCRIPTION
Some notes:
- The APE config is stored on a volume right now, this container won't run without copying a file to `/home/scv2/ape/apeConfig.json`
- build.sh seems to process the docker compose files in alphabetical order so it will prompt about this before anything else, including `base`. I looked into fixing this for a bit but bash is really hard to do anything in and not produce an unmaintainable mess

Resolves #88 