### PR TITLE
fix: bump mongo container default file handle limits (#94)

### DIFF
--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -35,6 +35,11 @@ services:
     hostname: ${PROJECT_PREFIX:-}mongo
     image: mongo:4.2.3-bionic
     restart: always
+    # Increase open file handle limits (https://github.com/pacefactory/deployment-scripts/issues/94)
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
     logging:
       driver: local
     expose:


### PR DESCRIPTION

Resolves #94
