### PR TITLE
Add ENV to limit the number for frames tracked in one run

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -85,7 +85,7 @@ services:
     environment:
       - "PF_REDIS_HOST=${PROJECT_PREFIX:-}redis"
       - PF_MONGO_HOST=${PROJECT_PREFIX:-}mongo_exp
-      - PF_TRACK_FRAME_BATCH_LIMIT=${PF_TRACK_FRAME_BATCH_LIMIT:10} 
+      - PF_TRACK_FRAME_BATCH_LIMIT=${PF_TRACK_FRAME_BATCH_LIMIT:-} 
     depends_on:
       mongo_exp:
         condition: service_started


### PR DESCRIPTION
Related to https://github.com/pacefactory/expresso_server/issues/79

Provides an ENV variable that can restrict how many frames are tracked at once with Xmem