### PR TITLE
Add control server URL config for expresso_ui

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -57,10 +57,14 @@ services:
     environment:
       - "PF_APIGATEWAY=true"
       - "PF_EXPRESSO_SERVER_PORT=8456"
+      - "PF_CONTROL_SERVER_URL="
     depends_on:
       expresso_server:
         condition: service_started
         required: true
+      realtime:
+        condition: service_started
+        required: false
 
   redis:
     container_name: ${PROJECT_PREFIX:-}redis


### PR DESCRIPTION
## Summary
- Add PF_CONTROL_SERVER_URL environment variable to expresso_ui service
- Add optional depends_on for realtime service (required: false)

## Test plan
- [x] Deploy with expresso profile enabled
- [x] Verify expresso_ui can connect to realtime via apigateway at `/api/realtime/`

## Related
- pacefactory/expresso_ui#69

Closes #114