### PR TITLE
Add DBSERVER_DISABLE_SNAPSHOT_IMAGES for tiered ghosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,39 @@ docker compose run --rm stitch_videos <date_string> [options]
 
 TODO: Document me!
 
+# Ghosting Configuration
+
+The platform supports tiered ghosting enforcement to control access to unghosted snapshot images.
+
+## Deployment Modes
+
+| Mode | `WEBGUI_FORCE_GHOSTING` | `DBSERVER_DISABLE_SNAPSHOT_IMAGES` | Description |
+|------|-------------------------|-------------------------------------|-------------|
+| **Hard** (default) | `true` | `true` | Maximum security. Webgui locked, dbserver snapshot image endpoints disabled. |
+| **Soft** | `true` | `false` | Webgui locked but `UNGHOSTED_CAMERA_LIST` works. DBServer endpoints available. |
+| **None** | `false` | `false` | Full user control over ghosting toggle. |
+
+## Environment Variables
+
+### WEBGUI_FORCE_GHOSTING
+- **Default:** `true`
+- Controls whether the ghosting toggle in the web UI is locked.
+
+### WEBGUI_UNGHOSTED_CAMERA_LIST
+- **Default:** `""` (empty)
+- Comma-separated list of camera names that can be displayed unghosted in the webgui.
+- Only effective when `WEBGUI_FORCE_GHOSTING=true` and `DBSERVER_DISABLE_SNAPSHOT_IMAGES=false` (soft mode).
+
+### DBSERVER_DISABLE_SNAPSHOT_IMAGES
+- **Default:** `true`
+- When `true`, snapshot image endpoints are not registered in dbserver (hard enforcement).
+- Gifwrapper automatically reads snapshots directly from the shared volume when this is enabled.
+
+## Migration Notes
+
+- **New deployments** default to hard enforcement (both variables `true`).
+- **Existing deployments** using `UNGHOSTED_CAMERA_LIST` should set `DBSERVER_DISABLE_SNAPSHOT_IMAGES=false` to maintain soft enforcement.
+
 # Advanced usage
 
 ## Backup realtime, auditgui and rdb configs

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -18,6 +18,9 @@ x-pf-info:
     WEBGUI_UNGHOSTED_CAMERA_LIST:
       description: List of cameras that should not be ghosted. Should be a comma separated list of camera names
       default: ""
+    DBSERVER_DISABLE_SNAPSHOT_IMAGES:
+      description: Disable unghosted snapshot image endpoints in dbserver (hard ghosting enforcement)
+      default: true
     GIFWRAPPER_TAG:
       default: latest
     DTREESERVER_TAG:
@@ -64,6 +67,7 @@ services:
     tty: true
     environment:
       - "MONGO_HOST=${PROJECT_PREFIX:-}mongo"
+      - "DBSERVER_DISABLE_SNAPSHOT_IMAGES=${DBSERVER_DISABLE_SNAPSHOT_IMAGES:-true}"
     volumes:
       - "dbserver-data:/home/scv2/volume"
     networks:
@@ -169,6 +173,10 @@ services:
       - dbserver
     environment:
       - "DBSERVER_HOST=${PROJECT_PREFIX:-}dbserver"
+      - "DBSERVER_DISABLE_SNAPSHOT_IMAGES=${DBSERVER_DISABLE_SNAPSHOT_IMAGES:-true}"
+      - "DBSERVER_VOLUME_DATA_PATH=/home/scv2/volume/data"
+    volumes:
+      - "dbserver-data:/home/scv2/volume:ro"
     networks:
       - external_network
 


### PR DESCRIPTION
## Summary

Add tiered ghosting enforcement with three deployment modes:

| Mode | `WEBGUI_FORCE_GHOSTING` | `DBSERVER_DISABLE_SNAPSHOT_IMAGES` | Description |
|------|-------------------------|-------------------------------------|-------------|
| **Hard** (default) | `true` | `true` | Maximum security. Webgui locked, dbserver snapshot image endpoints disabled. |
| **Soft** | `true` | `false` | Webgui locked but `UNGHOSTED_CAMERA_LIST` works. DBServer endpoints available. |
| **None** | `false` | `false` | Full user control over ghosting toggle. |

## Changes

- Add `DBSERVER_DISABLE_SNAPSHOT_IMAGES` setting to `x-pf-info` (default: `true`)
- Pass environment variable to dbserver and gifwrapper services
- Add read-only volume mount to gifwrapper for direct snapshot access
- Update README with ghosting configuration documentation

## Migration Notes

- New deployments default to hard enforcement
- Existing deployments using `UNGHOSTED_CAMERA_LIST` should set `DBSERVER_DISABLE_SNAPSHOT_IMAGES=false` to maintain soft enforcement

## Related

- Requires pacefactory/scv2_dbserver#112 for dbserver endpoint disabling
- Requires pacefactory/scv2_services_gifwrapper#43 for gifwrapper direct volume access

Closes #116