### PR TITLE
Expresso Tracking: Increase default Tracking Duration to 100

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -12,7 +12,7 @@ x-pf-info:
       default: latest
     PF_TRACK_FRAME_BATCH_LIMIT:
       description: Max number of frames tracked in a single run. Ram usage increases linearly with number of frames.
-      default: 10
+      default: 100
 
 services:
   expresso_server:


### PR DESCRIPTION

- Increase the default tracking duration to 100 in the x-pf-info