### PR TITLE
Add Validation Capture bucket size ENV to celery worker

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -43,6 +43,9 @@ services:
       # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT. 
       # The DBSERVER_URL is meant to be used for development.
       - "PF_DBSERVER_URL="
+      # Size of buckets to use in validation capture for creating datasets with consecutive images. The user
+      # has direct control over this value in the UI. This ENV is just for the default.
+      - PF_VALIDATION_CAPTURE_BUCKET_SIZE=${PF_VALIDATION_CAPTURE_BUCKET_SIZE:-15}
 
     depends_on:
       mongo:
@@ -113,9 +116,6 @@ services:
       # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT. 
       # The DBSERVER_URL is meant to be used for development.
       - "PF_DBSERVER_URL="
-      # Size of buckets to use in validation capture for creating datasets with consecutive images. The user
-      # has direct control over this value in the UI. This ENV is just for the default.
-      - PF_VALIDATION_CAPTURE_BUCKET_SIZE=${PF_VALIDATION_CAPTURE_BUCKET_SIZE:-15}
     depends_on:
       mongo_exp:
         condition: service_started

--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -8,6 +8,9 @@ x-pf-info:
     EXPRESSO_SERVER_TAG:
       default: latest
       default_var: EXPRESSO_SERVER_TAG_DEFAULT_GPU
+    PF_VALIDATION_CAPTURE_BUCKET_SIZE:
+      description: Default bucket duration used for creating datasets with consecutive images
+      default: 15
     EXPRESSO_UI_TAG:
       default: latest
 
@@ -110,6 +113,9 @@ services:
       # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT. 
       # The DBSERVER_URL is meant to be used for development.
       - "PF_DBSERVER_URL="
+      # Size of buckets to use in validation capture for creating datasets with consecutive images. The user
+      # has direct control over this value in the UI. This ENV is just for the default.
+      - PF_VALIDATION_CAPTURE_BUCKET_SIZE=${PF_VALIDATION_CAPTURE_BUCKET_SIZE:-15}
     depends_on:
       mongo_exp:
         condition: service_started


### PR DESCRIPTION
## Summary
- Adds `PF_VALIDATION_CAPTURE_BUCKET_SIZE` environment variable to the expresso celery worker service
- Configures the default bucket duration (15) used for creating datasets with consecutive images in validation capture
- Adds the setting to `x-pf-info` so it appears in the interactive build prompts

## Test plan
- [ ] Run `./build.sh` (or `./scripts/build-mac.sh` on macOS) and verify the new `PF_VALIDATION_CAPTURE_BUCKET_SIZE` prompt appears during expresso profile setup
- [ ] Verify the generated `docker-compose.yml` includes the new ENV on the celery worker service
- [ ] Confirm the default value of 15 is used when no override is set