### PR TITLE
Add expresso-030-trainer sub-profile

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -4,6 +4,7 @@ x-pf-info:
   description: The Expresso profile expresso_server and UI for easier configuration
   sub-profiles:
     - expresso-020-cuda
+    - expresso-030-trainer
   settings:
     EXPRESSO_SERVER_TAG:
       default: latest

--- a/compose/docker-compose.expresso-030-trainer.yml
+++ b/compose/docker-compose.expresso-030-trainer.yml
@@ -6,6 +6,9 @@ x-pf-info:
   settings:
     TRAINER_TAG:
       default: latest
+    TRAINER_SHM_SIZE:
+      default: 2gb
+      description: "Shared memory (/dev/shm) size for the trainer container. Increase if PyTorch DataLoader deadlocks (e.g. 4gb, 8gb)."
 
 services:
   trainer:
@@ -14,6 +17,7 @@ services:
     image: pacefactory/trainer:${TRAINER_TAG:-latest}
     entrypoint: [ "./scripts/start_worker.sh" ]
     restart: always
+    shm_size: ${TRAINER_SHM_SIZE:-2gb}
     logging:
       driver: local
     volumes:

--- a/compose/docker-compose.expresso-030-trainer.yml
+++ b/compose/docker-compose.expresso-030-trainer.yml
@@ -1,7 +1,7 @@
 x-pf-info:
   name: Expresso Trainer
   prompt: Enable the Trainer worker for Expresso?
-  description: Adds a GPU-backed Celery worker that runs model training (YOLOv8, YOLOX, RF-DETR) and synthetic data generation tasks dispatched by expresso_server. Requires an NVIDIA GPU and the nvidia container runtime on the host.
+  description: Adds a GPU-backed Celery worker that runs model training and synthetic data generation tasks dispatched by expresso_server. Requires an NVIDIA GPU and the nvidia container runtime on the host.
   sub-profile: true
   settings:
     TRAINER_TAG:

--- a/compose/docker-compose.expresso-030-trainer.yml
+++ b/compose/docker-compose.expresso-030-trainer.yml
@@ -1,0 +1,49 @@
+x-pf-info:
+  name: Expresso Trainer
+  prompt: Enable the Trainer worker for Expresso?
+  description:
+    Adds a GPU-backed Celery worker that runs model training (YOLOv8, YOLOX,
+    RF-DETR) and synthetic data generation tasks dispatched by expresso_server.
+    Requires an NVIDIA GPU and the nvidia container runtime on the host.
+  sub-profile: true
+  settings:
+    TRAINER_TAG:
+      default: latest
+
+services:
+  trainer_worker:
+    container_name: ${PROJECT_PREFIX:-}trainer_worker
+    hostname: ${PROJECT_PREFIX:-}trainer_worker
+    image: pacefactory/trainer:${TRAINER_TAG:-latest}
+    entrypoint: ["./scripts/start_worker.sh"]
+    restart: always
+    logging:
+      driver: local
+    volumes:
+      - expresso-data:/home/scv2/volume
+    networks:
+      - external_network
+      - expresso_network
+    environment:
+      - "PF_REDIS_HOST=${PROJECT_PREFIX:-}redis"
+      - "PF_MONGO_HOST=${PROJECT_PREFIX:-}mongo_exp"
+      - "PF_TRAINER_VOLUME_PATH=/home/scv2/volume"
+      - "PF_PREFER_GPU=true"
+    depends_on:
+      mongo_exp:
+        condition: service_started
+        required: true
+      redis:
+        condition: service_started
+        required: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu
+                - utility
+                - compute
+                - video

--- a/compose/docker-compose.expresso-030-trainer.yml
+++ b/compose/docker-compose.expresso-030-trainer.yml
@@ -11,9 +11,9 @@ x-pf-info:
       default: latest
 
 services:
-  trainer_worker:
-    container_name: ${PROJECT_PREFIX:-}trainer_worker
-    hostname: ${PROJECT_PREFIX:-}trainer_worker
+  trainer:
+    container_name: ${PROJECT_PREFIX:-}trainer
+    hostname: ${PROJECT_PREFIX:-}trainer
     image: pacefactory/trainer:${TRAINER_TAG:-latest}
     entrypoint: ["./scripts/start_worker.sh"]
     restart: always

--- a/compose/docker-compose.expresso-030-trainer.yml
+++ b/compose/docker-compose.expresso-030-trainer.yml
@@ -1,10 +1,7 @@
 x-pf-info:
   name: Expresso Trainer
   prompt: Enable the Trainer worker for Expresso?
-  description:
-    Adds a GPU-backed Celery worker that runs model training (YOLOv8, YOLOX,
-    RF-DETR) and synthetic data generation tasks dispatched by expresso_server.
-    Requires an NVIDIA GPU and the nvidia container runtime on the host.
+  description: Adds a GPU-backed Celery worker that runs model training (YOLOv8, YOLOX, RF-DETR) and synthetic data generation tasks dispatched by expresso_server. Requires an NVIDIA GPU and the nvidia container runtime on the host.
   sub-profile: true
   settings:
     TRAINER_TAG:
@@ -15,7 +12,7 @@ services:
     container_name: ${PROJECT_PREFIX:-}trainer
     hostname: ${PROJECT_PREFIX:-}trainer
     image: pacefactory/trainer:${TRAINER_TAG:-latest}
-    entrypoint: ["./scripts/start_worker.sh"]
+    entrypoint: [ "./scripts/start_worker.sh" ]
     restart: always
     logging:
       driver: local
@@ -28,7 +25,7 @@ services:
       - "PF_REDIS_HOST=${PROJECT_PREFIX:-}redis"
       - "PF_MONGO_HOST=${PROJECT_PREFIX:-}mongo_exp"
       - "PF_TRAINER_VOLUME_PATH=/home/scv2/volume"
-      - "PF_PREFER_GPU=true"
+      - "PF_EXPRESSO_HOST=${PROJECT_PREFIX:-}expresso_server"
     depends_on:
       mongo_exp:
         condition: service_started


### PR DESCRIPTION
## Summary
- Adds a new `expresso-030-trainer` sub-profile under `expresso-010` that layers a `trainer_worker` Celery service into the Expresso stack.
- Trainer reuses the existing `expresso-data` volume, `expresso_network` + `external_network`, `redis` broker, and `mongo_exp` instance (writing to its own `trainer` database).
- GPU reservation (`nvidia` driver, all devices, gpu/utility/compute/video capabilities) and `PF_PREFER_GPU=true` are bundled into the sub-profile since the trainer is GPU-only in practice — no separate CUDA toggle.
- New `TRAINER_TAG` setting (default `latest`) for pinning the `pacefactory/trainer` image.

Closes pacefactory/deployment-scripts#151
Related: pacefactory/trainer#49

## Test plan
- [x] `./build.sh` prompts "Enable the Trainer worker for Expresso?" after the existing CUDA prompt
- [x] `TRAINER_TAG [latest]:` prompt appears
- [x] Generated `docker-compose.yml` includes a `trainer_worker` service with the expected image, entrypoint, env vars, both networks, GPU reservation, and `depends_on: [mongo_exp, redis]`
- [x] `docker compose up -d trainer_worker` brings the worker up; logs show `Trainer worker initialized` and `Starting Trainer Celery worker...`
- [x] `redis-cli GET trainer:heartbeat` returns `"alive"` within ~15s
- [x] `mongosh --eval 'use trainer; show collections'` lists `tracking_queue` and `synth_queue`
- [x] Declining the trainer prompt regenerates a `docker-compose.yml` with no `trainer_worker` service