### PR TITLE
Add celery_beat service to Expresso profile

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -118,6 +118,26 @@ services:
         condition: service_started
         required: true
 
+  # Singleton: never scale this service. Two beat replicas would enqueue every
+  # scheduled task twice.
+  celery_beat:
+    container_name: ${PROJECT_PREFIX:-}celery_beat
+    hostname: ${PROJECT_PREFIX:-}celery_beat
+    image: pacefactory/expresso_server:${EXPRESSO_SERVER_TAG:-${EXPRESSO_SERVER_TAG_DEFAULT_GPU:-latest}}
+    entrypoint: ["./scripts/start_beat.sh"]
+    restart: always
+    logging:
+      driver: local
+    networks:
+      - expresso_network
+    environment:
+      - "PF_REDIS_HOST=${PROJECT_PREFIX:-}redis"
+      - PF_MONGO_HOST=${PROJECT_PREFIX:-}mongo_exp
+    depends_on:
+      redis:
+        condition: service_started
+        required: true
+
   mongo_exp:
     container_name: ${PROJECT_PREFIX:-}mongo_exp
     hostname: ${PROJECT_PREFIX:-}mongo_exp

--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -105,9 +105,14 @@ services:
     environment:
       - "PF_REDIS_HOST=${PROJECT_PREFIX:-}redis"
       - PF_MONGO_HOST=${PROJECT_PREFIX:-}mongo_exp
+      - PF_CONTROL_SERVER_HOST=${PROJECT_PREFIX:-}realtime
+      - PF_CONTROL_SERVER_PORT=8181
+      # Override to connect directly to the control server (for development).
+      # When empty, falls back to CONTROL_SERVER_HOST and CONTROL_SERVER_PORT
+      - "PF_CONTROL_SERVER_URL="
       - PF_DBSERVER_HOST=${PROJECT_PREFIX:-}dbserver
       - PF_DBSERVER_PORT=8050
-      # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT. 
+      # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT.
       # The DBSERVER_URL is meant to be used for development.
       - "PF_DBSERVER_URL="
     depends_on:


### PR DESCRIPTION
## Summary
- Adds a `celery_beat` service to `compose/docker-compose.expresso-010.yml` so scheduled Celery tasks fire in deployments built by `build.sh`.
- Beat is the scheduler for the hourly bootstrap-validation-capture orchestrator (expresso_server PR #231) and the existing heartbeat task.
- Singleton: only one beat replica may run at a time. Scaling would enqueue every scheduled task twice; a comment in the compose file documents this.

## Notable choices
- Lives in the base Expresso profile (not the CUDA sub-profile) — beat doesn't need GPU.
- Uses the same `pacefactory/expresso_server` image as the worker; entrypoint is `./scripts/start_beat.sh`, which targets the slim `expresso.scheduling.beat_app` Celery app (no torch/cv2 imported in the beat process).
- `depends_on` only `redis` (broker). `PF_MONGO_HOST` is set because `Settings()` validates it at import, even though beat doesn't query Mongo.
- No volume mount: beat persists its schedule to `/tmp/celerybeat-schedule`, which is ephemeral by design — the in-code `beat_schedule` is the source of truth.

## Test plan
- [x] `./build.sh` (or `./scripts/build-mac.sh`) with the Expresso profile enabled produces a `docker-compose.yml` containing the new `celery_beat` service with the expected image, entrypoint, env, and `depends_on: redis`.
- [x] `./update.sh` brings the stack up; `docker compose ps` shows `celery_beat` as `Up`.
- [x] `docker compose logs celery_beat` shows `Scheduler: Sending due task heartbeat` (and hourly `bootstrap_validation_capture_tick`).
- [x] `docker compose logs celery_worker | grep -E "heartbeat|bootstrap"` shows the worker receiving and executing the dispatched tasks.
- [x] CUDA overlay (`expresso-020-cuda`) still applies only to `celery_worker`; `celery_beat` does not request GPU resources.

Closes #155