### PR TITLE
Add dbserver volume mount to expresso service

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -21,6 +21,10 @@ services:
       driver: local
     volumes:
       - expresso-data:/home/scv2/volume
+      # Read-only mount of the dbserver data volume so the stations config UI
+      # can fetch snapshot JPEGs directly from disk when DBSERVER_DISABLE_SNAPSHOT_IMAGES
+      # is true on the dbserver (the default). Same strategy as service_gifwrapper.
+      - "dbserver-data:/home/scv2/dbserver_volume:ro"
     # Ports are conditionally enabled in the expresso-ports profile
     networks:
       - external_network
@@ -37,9 +41,14 @@ services:
       - "PF_CONTROL_SERVER_URL="
       - PF_DBSERVER_HOST=${PROJECT_PREFIX:-}dbserver
       - PF_DBSERVER_PORT=8050
-      # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT. 
+      # The PF_DBSERVER_URL overrides the DBSERVER_HOST and DBSERVER_PORT.
       # The DBSERVER_URL is meant to be used for development.
       - "PF_DBSERVER_URL="
+      # Root of the mounted dbserver data volume. When set, expresso_server
+      # reads snapshot images directly from disk rather than via the dbserver
+      # HTTP API, which is disabled by default for privacy
+      # (DBSERVER_DISABLE_SNAPSHOT_IMAGES=true).
+      - "PF_DBSERVER_VOLUME_DATA_PATH=/home/scv2/dbserver_volume/data"
 
     depends_on:
       mongo:


### PR DESCRIPTION
## Summary
Enable the expresso service to read snapshot images directly from the dbserver data volume instead of fetching them via HTTP API, improving performance and aligning with the dbserver's privacy-first default configuration.

## Changes
- Added read-only mount of `dbserver-data` volume to expresso service at `/home/scv2/dbserver_volume`
- Added `PF_DBSERVER_VOLUME_DATA_PATH` environment variable pointing to the mounted volume's data directory
- Added explanatory comments documenting the rationale: when `DBSERVER_DISABLE_SNAPSHOT_IMAGES=true` on dbserver (the default), expresso can fetch snapshots directly from disk instead of via HTTP API
- Fixed trailing whitespace in existing comment

## Implementation Details
- The volume mount is read-only (`:ro`) to prevent accidental modifications
- This follows the same strategy already used by the `service_gifwrapper` service
- The configuration allows the stations config UI to function properly even when the dbserver has snapshot image serving disabled for privacy reasons

https://claude.ai/code/session_01JZhexx9kSKDikgzQF8qatg