### PR TITLE
Add remote-trainer env vars to expresso_server service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@
 # GIFWRAPPER_PUBLIC_PORT=7171
 
 # SOCIAL_WEB_APP_TAG=latest
+
+# Remote-training (expresso_server only):
+# EXPRESSO_PUBLIC_URL_BASE=https://site.example.com/api/expresso
+# PF_REMOTE_TRAINER_URLS=https://siteB.example.com,https://siteC.example.com

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,5 @@
 # SOCIAL_WEB_APP_TAG=latest
 
 # Remote-training (expresso_server only):
-# EXPRESSO_PUBLIC_URL_BASE=https://site.example.com/api/expresso
+# PF_EXPRESSO_PUBLIC_URL_BASE=https://site.example.com/api/expresso
 # PF_REMOTE_TRAINER_URLS=https://siteB.example.com,https://siteC.example.com

--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -11,7 +11,7 @@ x-pf-info:
       default_var: EXPRESSO_SERVER_TAG_DEFAULT_GPU
     EXPRESSO_UI_TAG:
       default: latest
-    EXPRESSO_PUBLIC_URL_BASE:
+    PF_EXPRESSO_PUBLIC_URL_BASE:
       description: >-
         Public URL other deployments use to reach this one for remote-training
         callbacks, including scheme and the /api/expresso prefix
@@ -65,9 +65,9 @@ services:
       - "PF_DBSERVER_VOLUME_DATA_PATH=/home/scv2/dbserver_volume/data"
       # Externally-reachable base URL of THIS deployment, used to build the
       # remote-training callback endpoint (<base>/training/remote/callback).
-      # No PF_ prefix by design. Empty = this deployment cannot originate
-      # remote training jobs (local training still works).
-      - "EXPRESSO_PUBLIC_URL_BASE=${EXPRESSO_PUBLIC_URL_BASE:-}"
+      # Empty = this deployment cannot originate remote training jobs
+      # (local training still works).
+      - "PF_EXPRESSO_PUBLIC_URL_BASE=${PF_EXPRESSO_PUBLIC_URL_BASE:-}"
       # Optional comma-separated remote Expresso base URLs pre-registered as
       # remote trainers at startup (idempotent).
       - "PF_REMOTE_TRAINER_URLS=${PF_REMOTE_TRAINER_URLS:-}"

--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -21,7 +21,7 @@ x-pf-info:
     PF_REMOTE_TRAINER_URLS:
       description: >-
         Optional comma-separated remote Expresso base URLs to pre-register as
-        remote trainers (e.g. https://siteB.example.com,https://siteC.example.com).
+        remote trainers (e.g. https://siteB.example.com/api/expresso,https://siteC.example.com/api/expresso).
         Leave blank to add them later via the UI/API.
       default: ""
 

--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -11,6 +11,19 @@ x-pf-info:
       default_var: EXPRESSO_SERVER_TAG_DEFAULT_GPU
     EXPRESSO_UI_TAG:
       default: latest
+    EXPRESSO_PUBLIC_URL_BASE:
+      description: >-
+        Public URL other deployments use to reach this one for remote-training
+        callbacks, including scheme and the /api/expresso prefix
+        (e.g. https://site.example.com/api/expresso). Leave blank if this
+        deployment will not dispatch training to a remote.
+      default: ""
+    PF_REMOTE_TRAINER_URLS:
+      description: >-
+        Optional comma-separated remote Expresso base URLs to pre-register as
+        remote trainers (e.g. https://siteB.example.com,https://siteC.example.com).
+        Leave blank to add them later via the UI/API.
+      default: ""
 
 services:
   expresso_server:
@@ -50,6 +63,14 @@ services:
       # HTTP API, which is disabled by default for privacy
       # (DBSERVER_DISABLE_SNAPSHOT_IMAGES=true).
       - "PF_DBSERVER_VOLUME_DATA_PATH=/home/scv2/dbserver_volume/data"
+      # Externally-reachable base URL of THIS deployment, used to build the
+      # remote-training callback endpoint (<base>/training/remote/callback).
+      # No PF_ prefix by design. Empty = this deployment cannot originate
+      # remote training jobs (local training still works).
+      - "EXPRESSO_PUBLIC_URL_BASE=${EXPRESSO_PUBLIC_URL_BASE:-}"
+      # Optional comma-separated remote Expresso base URLs pre-registered as
+      # remote trainers at startup (idempotent).
+      - "PF_REMOTE_TRAINER_URLS=${PF_REMOTE_TRAINER_URLS:-}"
 
     depends_on:
       mongo:


### PR DESCRIPTION
## Summary

Adds the two environment variables the remote-training feature needs to the Expresso deployment, scoped to the **`expresso_server`** web/API service only (not the celery worker / trainer services).

`expresso_server` can forward a training job to a remote Expresso deployment that owns a trainer. The remote needs a callback URL to POST the finished model back to, and the origin deployment supplies that URL via an environment variable. Until now the compose file set no externally-reachable URL — `expresso_server` only knew internal Docker service names and `PF_ROOT_PATH=/api/expresso`.

### Variables added (on `expresso_server` only)

- **`EXPRESSO_PUBLIC_URL_BASE`** — *no `PF_` prefix, by design.* This deployment's externally-reachable base URL, used to build `<base>/training/remote/callback`. Required only on a deployment that may dispatch training to a remote; empty otherwise (local training and acting-as-a-remote-host are unaffected).
- **`PF_REMOTE_TRAINER_URLS`** — keeps the `PF_` prefix. Optional, comma-separated list of remote Expresso base URLs to pre-register as remote trainers at startup (idempotent). Can be left empty; remotes can also be added later via the API/UI.

## Approach

Both are added as **interactive prompted settings** in the `expresso-010` profile's `x-pf-info.settings` block, each with an empty default and a clear description — matching the existing pattern used by `SERVER_NAME`. `build.sh` only writes a setting to `.env` when its value is non-empty, so an empty default produces no `.env` line and the compose `${VAR:-}` fallback resolves to empty: exactly the "leave empty → cannot originate remote jobs" behavior.

The operator enters the full public URL (scheme + host + the `/api/expresso` gateway prefix this deployment uses, e.g. `https://customer.pacefactory.com/api/expresso`), keeping correctness in human hands and avoiding hardcoding one site's URL across deployments.

Auto-deriving from `SERVER_NAME` was rejected: it's a bare hostname (no scheme, no `/api/expresso` root path) and varies across HTTPS profiles (e.g. `https-digitalocean` appends `.pacefactory.dev`), so derivation would risk a silently wrong callback URL.

## Changes

- `compose/docker-compose.expresso-010.yml` — two new prompted settings; two new env vars on the `expresso_server` service only.
- `.env.example` — commented reference entries.

## Verification

- `docker compose ... config` renders valid YAML.
- With values set, both vars appear on **only** `expresso_server`; absent from `celery_worker` / `celery_beat` / `expresso_ui` / `trainer`.
- With nothing set, both resolve to `""` on `expresso_server`.
- `yq` parses all four profile settings, confirming `build.sh`'s prompt loop picks up the two new ones.

The startup-log acceptance check (`Public URL base (remote training callbacks): <url>`) depends on server-side code that lives in a separate change; this PR is the deployment-config side only, using the exact variable names specified.

https://claude.ai/code/session_01Vme6uzXmVg28JyXGzLjEnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vme6uzXmVg28JyXGzLjEnH)_