### PR TITLE
Add remote fleet update tooling for Windows-based deployments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 * text=auto
+
+# Shell scripts must stay LF even on Windows checkouts: update-fleet.ps1
+# streams scripts/remote/update-server.sh to a remote 'bash -s', and CRLF
+# line endings would break it.
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docker-compose.yml
 credentials/*/credentials.ini
 credentials/*/fullchain.pem
 credentials/*/privkey.pem
+scripts/remote/servers.txt
+scripts/remote/logs/

--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ No restore step needed -- data goes directly into Docker volumes on the new serv
 ./scripts/backup_restore/restore_volume.sh -i /path/to/backup-files
 ```
 
+## Remote Fleet Updates (from Windows)
+
+`scripts/remote/` contains tooling to run `git pull` + `build.sh -q` +
+`update.sh -q` across many servers over ssh from a Windows machine (built-in
+OpenSSH client only, no admin rights), with per-server health checks, detection
+of pacefactory images pinned to non-`latest` tags, and a summary report.
+See [scripts/remote/README.md](scripts/remote/README.md).
+
 ## Compose Files
 
 ### Profile System

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -1,0 +1,165 @@
+# Remote fleet updates (from Windows)
+
+Semi-automated `git pull` + `build.sh` + `update.sh` across a fleet of
+deployment servers, run from a Windows machine over ssh.
+
+Designed for locked-down environments: it only needs the **built-in Windows
+OpenSSH client** and PowerShell 5.1+ — no admin rights, no third-party
+software.
+
+| File | Purpose |
+| --- | --- |
+| `install-ssh-key.ps1` | One-time setup: create a key and install it on every server |
+| `update-fleet.ps1` | Routine use: run the update payload on every server, report results |
+| `update-server.sh` | The payload that runs on each server (streamed over ssh, never copied) |
+| `servers.example.txt` | Template for your server list |
+
+## Prerequisites
+
+- Windows 10 1809+ / Windows 11 with the OpenSSH client (check with `ssh -V`
+  in PowerShell — it ships enabled by default).
+- PowerShell 5.1+ (the Windows default is fine).
+- The `pacefactory` account password for each server (needed once, during
+  key installation).
+- Each server already set up the usual way: repo cloned at
+  `~/scv2/git_clones/deployment-scripts`, `~/connect-to-proxy.sh` present
+  (optional), docker registry credentials already stored for the account.
+
+If script execution is blocked on your machine, run the scripts as:
+
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File .\update-fleet.ps1
+```
+
+(If a GPO enforces `AllSigned`, that bypass won't work — talk to IT.)
+
+## One-time setup
+
+1. Get this repo onto the Windows machine (clone it, or copy this folder).
+2. In this folder, copy `servers.example.txt` to `servers.txt` and put one
+   hostname/IP per line. `servers.txt` is gitignored — it never gets
+   committed.
+3. Run the key installer and follow the prompts:
+
+   ```powershell
+   cd scripts\remote
+   powershell.exe -ExecutionPolicy Bypass -File .\install-ssh-key.ps1
+   ```
+
+   For each server you'll be asked to confirm the host key (type `yes`) and
+   enter the password **once**. The script then verifies key-based auth
+   actually works. Re-running it is always safe; it skips servers that are
+   already set up.
+
+## Routine use
+
+```powershell
+# Update every server in servers.txt:
+powershell.exe -ExecutionPolicy Bypass -File .\update-fleet.ps1
+
+# Read-only preflight: reachability, commits behind origin, current tags, health:
+.\update-fleet.ps1 -DryRun
+
+# Just one server (any alternate list file works):
+.\update-fleet.ps1 -ServerList .\just-one.txt
+
+# Treat warnings (non-standard tags, degraded containers) as failures:
+.\update-fleet.ps1 -FailOnWarn
+
+# Less console noise, slower services need longer before the health check:
+.\update-fleet.ps1 -Quiet -HealthDelaySec 60
+```
+
+Servers are processed **sequentially**, and a failure on one server never
+stops the rest of the run.
+
+## What a run does on each server
+
+1. `source ~/connect-to-proxy.sh` (warning if missing, not fatal)
+2. `cd ~/scv2/git_clones/deployment-scripts`
+3. `git pull --ff-only`
+4. `./build.sh -q` (then validates the generated `docker-compose.yml`)
+5. Scan the resolved compose file for **pacefactory images whose tag is not
+   `latest`/`latest-gpu`** — e.g. a service pinned to `:1.4.2` for a site.
+   These are *reported, not blocking*: the run continues and the server shows
+   up as `WARN`. To clear one, fix the pinned `*_TAG` value in the server's
+   `.env` (or re-run `./build.sh` there) — pins live per-server, on purpose.
+6. `./update.sh -q` (pull images + relaunch)
+7. After a short settle delay (`-HealthDelaySec`, default 15s), check that
+   every container of the compose project is `Up` and not `(unhealthy)`.
+
+`-DryRun` replaces 3–6 with `git fetch` + "commits behind origin" and checks
+current state only — nothing on the server is modified.
+
+## Reading the output
+
+Each run writes `logs\<timestamp>\`:
+
+- `<server>.log` — full remote output plus ssh transport errors per server
+- `summary.csv` — one row per server (status, commits before/after,
+  non-standard tags, container counts, per-step exit codes, log path)
+
+Statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `OK` | Updated; all containers up |
+| `WARN` | Updated, but needs attention: non-standard tags, degraded containers, or missing proxy script |
+| `FAIL` | A step failed — see Detail and the server's log file |
+| `UNREACHABLE` | ssh could not connect (DNS, network, auth) |
+
+Script exit code: `0` all OK/WARN, `1` any FAIL/UNREACHABLE (and WARN too
+with `-FailOnWarn`), `2` usage/preflight error.
+
+Payload exit codes (the `PayloadExit` CSV column): `11` repo dir missing,
+`12` git pull failed, `13` build failed or produced an invalid compose file,
+`14` update.sh failed, `15` no containers found, `16` degraded containers.
+A step rc of `124` means that step hit its timeout (pull 10 min, build
+15 min, update 60 min).
+
+The payload prints machine-readable `PF|...` marker lines (BEGIN/STEP/TAG/
+HEALTH/INFO/END) between the normal command output; the orchestrator parses
+those, and they make the raw logs easy to skim too.
+
+### Why FAIL can appear even when scripts "succeeded"
+
+`update.sh`/`build.sh` can exit 0 even when a pull or compose generation
+failed, so the payload doesn't trust exit codes alone: it validates the
+generated `docker-compose.yml`, requires update.sh's "Deployment complete"
+message, and independently checks containers via `docker ps`.
+
+## Caveats
+
+- The health check is a **snapshot** taken ~15s after `up`: a container that
+  crash-loops later can be missed, and a slow starter can show up as
+  transiently degraded. Treat `WARN` as "go look", and bump
+  `-HealthDelaySec` for slow sites.
+- `git pull --ff-only` fails on purpose if a server's clone has diverged
+  (local commits). Fix that server by hand (`git status` there), then re-run.
+
+## Troubleshooting
+
+- **UNREACHABLE**: check VPN/network, DNS, and that you can
+  `ssh pacefactory@<server>` manually from the same machine.
+- **`REMOTE HOST IDENTIFICATION HAS CHANGED`**: the server was reinstalled
+  (or something worse). After confirming why, remove the old line from
+  `%USERPROFILE%\.ssh\known_hosts` and re-run `install-ssh-key.ps1`.
+- **Key auth still fails after install**: re-run `install-ssh-key.ps1` (it
+  applies `restorecon`, which fixes the usual RHEL/SELinux label problem).
+  Also check on the server that the home directory is not group/other
+  writable: `chmod go-w ~ ~/.ssh`.
+- **`Bad configuration option: accept-new`**: very old OpenSSH client;
+  re-run with `-HostKeyPolicy yes` (safe because the installer already put
+  the servers in `known_hosts`).
+- **Proxy warnings**: the payload continues without
+  `~/connect-to-proxy.sh`; if git/docker then fail on that server, the proxy
+  script is missing where it is actually needed.
+
+## Security notes
+
+- The key is a dedicated, passphrase-less ed25519 key for the `pacefactory`
+  account only (default `%USERPROFILE%\.ssh\pf_fleet_ed25519`). Don't reuse
+  it for anything else; revoke it by deleting its line from
+  `~/.ssh/authorized_keys` on the servers.
+- `servers.txt` and `logs/` are gitignored: real hostnames and run output
+  never get committed.

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -73,6 +73,12 @@ powershell.exe -ExecutionPolicy Bypass -File .\update-fleet.ps1
 Servers are processed **sequentially**, and a failure on one server never
 stops the rest of the run.
 
+Press **Ctrl+C** to stop gracefully: the server currently being updated
+finishes (so it is never left half-migrated), the servers not yet reached are
+marked `SKIPPED`, and the summary and per-server logs are still written. Note
+that Ctrl+C does *not* abort the server in progress — if it is mid-pull on a
+large image, it runs to completion before the run stops.
+
 ## What a run does on each server
 
 1. `source ~/connect-to-proxy.sh` (warning if missing, not fatal)
@@ -107,6 +113,7 @@ Statuses:
 | `WARN` | Updated, but needs attention: non-standard tags, degraded containers, or missing proxy script |
 | `FAIL` | A step failed — see Detail and the server's log file |
 | `UNREACHABLE` | ssh could not connect (DNS, network, auth) |
+| `SKIPPED` | Not attempted; the run was cancelled with Ctrl+C |
 
 Script exit code: `0` all OK/WARN, `1` any FAIL/UNREACHABLE (and WARN too
 with `-FailOnWarn`), `2` usage/preflight error.

--- a/scripts/remote/install-ssh-key.ps1
+++ b/scripts/remote/install-ssh-key.ps1
@@ -1,0 +1,217 @@
+<#
+.SYNOPSIS
+    One-time setup for the fleet update tooling: creates a dedicated ssh key
+    (if needed) and installs it on every server in the list.
+
+.DESCRIPTION
+    For each server in the list (default: servers.txt next to this script):
+
+      1. Probes whether key-based auth already works (skipped with -Force).
+      2. If not, connects interactively - you will be asked to confirm the
+         host key on first contact (type 'yes') and to enter the account
+         password ONCE - and appends the public key to ~/.ssh/authorized_keys
+         with correct permissions. On SELinux hosts (RHEL) it also runs
+         restorecon, which fixes the classic "key auth silently ignored"
+         problem.
+      3. Re-probes to verify key-based auth now works.
+
+    The interactive connection also records each server in known_hosts, so
+    later update-fleet.ps1 runs never see a host-key prompt.
+
+    Only the built-in Windows OpenSSH client is required (no admin rights).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\install-ssh-key.ps1
+
+.EXAMPLE
+    .\install-ssh-key.ps1 -ServerList .\new-servers.txt
+
+.NOTES
+    Exit codes: 0 = key works on every server, 1 = at least one failure,
+    2 = preflight error.
+#>
+[CmdletBinding()]
+param(
+    [string]$ServerList = (Join-Path $PSScriptRoot 'servers.txt'),
+    [string]$User = 'pacefactory',
+    [string]$KeyPath = (Join-Path $env:USERPROFILE '.ssh\pf_fleet_ed25519'),
+    [switch]$Force
+)
+
+# Deliberately NOT setting $ErrorActionPreference = 'Stop': in PowerShell 5.1
+# that turns native-command stderr (with 2>&1) into terminating errors.
+
+function Write-Warn([string]$Message) {
+    Write-Host ('WARNING: {0}' -f $Message) -ForegroundColor Yellow
+}
+
+function Fail-Preflight([string]$Message) {
+    Write-Host ('ERROR: {0}' -f $Message) -ForegroundColor Red
+    exit 2
+}
+
+function Resolve-OpenSshTool([string]$Name) {
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $fallback = Join-Path $env:WINDIR ('System32\OpenSSH\{0}' -f $Name)
+    if (Test-Path -LiteralPath $fallback) { return $fallback }
+    return $null
+}
+
+function Read-ServerList([string]$Path) {
+    $servers = New-Object System.Collections.ArrayList
+    $seen = @{}
+    foreach ($raw in @(Get-Content -LiteralPath $Path)) {
+        $line = ('{0}' -f $raw).Trim()
+        if ($line -eq '') { continue }
+        if ($line.StartsWith('#')) { continue }
+        if ($line -notmatch '^[A-Za-z0-9.:_-]+$') {
+            Write-Warn ('skipping invalid server entry: "{0}"' -f $line)
+            continue
+        }
+        $key = $line.ToLowerInvariant()
+        if ($seen.ContainsKey($key)) { continue }
+        $seen[$key] = $true
+        [void]$servers.Add($line)
+    }
+    return , $servers
+}
+
+# Non-interactive probe: does key-based auth work right now?
+function Test-KeyAuth([string]$SshExe, [string]$Key, [string]$Target) {
+    $out = ''
+    try {
+        $out = (& $SshExe -i $Key -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=10 $Target 'echo PF_KEY_OK' 2>&1 | Out-String)
+    }
+    catch {
+        return $false
+    }
+    if ($LASTEXITCODE -ne 0) { return $false }
+    return ($out -match 'PF_KEY_OK')
+}
+
+# ---- preflight ---------------------------------------------------------------
+
+$sshExe = Resolve-OpenSshTool 'ssh.exe'
+$sshKeygenExe = Resolve-OpenSshTool 'ssh-keygen.exe'
+if (-not $sshExe) {
+    Fail-Preflight 'ssh.exe not found. The built-in Windows OpenSSH client is required (Windows 10 1809+ / Windows 11).'
+}
+if (-not $sshKeygenExe) {
+    Fail-Preflight 'ssh-keygen.exe not found (it ships with the built-in Windows OpenSSH client).'
+}
+if (-not (Test-Path -LiteralPath $ServerList)) {
+    Fail-Preflight ('server list not found: {0} (copy servers.example.txt to servers.txt and edit it)' -f $ServerList)
+}
+
+$servers = Read-ServerList $ServerList
+if ($servers.Count -eq 0) {
+    Fail-Preflight ('no servers found in {0}' -f $ServerList)
+}
+
+# ---- key generation (idempotent) ----------------------------------------------
+
+if (Test-Path -LiteralPath $KeyPath) {
+    Write-Host ('Using existing key: {0}' -f $KeyPath)
+}
+else {
+    $keyDir = Split-Path -Parent $KeyPath
+    if (($keyDir -ne '') -and (-not (Test-Path -LiteralPath $keyDir))) {
+        [void](New-Item -ItemType Directory -Path $keyDir -Force)
+    }
+    $comment = ('pf-fleet-{0}@{1}' -f $env:USERNAME, $env:COMPUTERNAME)
+    Write-Host ('Generating new ed25519 key: {0}' -f $KeyPath)
+    # '""' is how PowerShell 5.1 passes an empty -N (no passphrase) argument.
+    & $sshKeygenExe -t ed25519 -f $KeyPath -N '""' -C $comment
+    if (-not (Test-Path -LiteralPath $KeyPath)) {
+        Write-Warn 'ssh-keygen did not accept the empty passphrase argument; retrying interactively.'
+        Write-Host 'When asked for a passphrase, press Enter twice to leave it empty.'
+        & $sshKeygenExe -t ed25519 -f $KeyPath -C $comment
+    }
+    if (-not (Test-Path -LiteralPath $KeyPath)) {
+        Fail-Preflight 'key generation failed'
+    }
+}
+
+$pubKeyPath = ('{0}.pub' -f $KeyPath)
+if (-not (Test-Path -LiteralPath $pubKeyPath)) {
+    Fail-Preflight ('public key not found: {0}' -f $pubKeyPath)
+}
+$pubKey = ([System.IO.File]::ReadAllText($pubKeyPath)).Trim()
+
+# The key is embedded between single quotes in a remote shell command, so be
+# strict about what it may contain.
+if ($pubKey -notmatch '^ssh-ed25519 [A-Za-z0-9+/=]+( [A-Za-z0-9@._-]+)?$') {
+    Fail-Preflight ('unexpected public key format in {0}' -f $pubKeyPath)
+}
+
+Write-Host 'Key fingerprint:'
+& $sshKeygenExe -lf $pubKeyPath
+Write-Host ''
+
+# Appends the key (exact-line dedupe, so re-runs are harmless), fixes
+# permissions, and restores SELinux labels where applicable.
+$remoteCmd = (@(
+        'umask 077',
+        'mkdir -p ~/.ssh',
+        'chmod 700 ~/.ssh',
+        'touch ~/.ssh/authorized_keys',
+        'chmod 600 ~/.ssh/authorized_keys',
+        ("grep -qxF '{0}' ~/.ssh/authorized_keys || printf '%s\n' '{0}' >> ~/.ssh/authorized_keys" -f $pubKey),
+        'if command -v restorecon >/dev/null 2>&1; then restorecon -R ~/.ssh; fi',
+        'echo PF_KEY_INSTALLED'
+    ) -join '; ')
+
+# ---- per-server install --------------------------------------------------------
+
+$results = New-Object System.Collections.ArrayList
+
+foreach ($server in $servers) {
+    $target = ('{0}@{1}' -f $User, $server)
+    Write-Host ('>>> {0}' -f $target) -ForegroundColor Cyan
+
+    if ((-not $Force) -and (Test-KeyAuth $sshExe $KeyPath $target)) {
+        Write-Host '    key auth already works, skipping'
+        [void]$results.Add([pscustomobject]@{ Server = $server; Status = 'AlreadyInstalled'; Detail = '' })
+        continue
+    }
+
+    Write-Host ('    Connecting interactively. If asked about the host key, type "yes".')
+    Write-Host ('    Then enter the password for {0} (this is the only time it is needed).' -f $target)
+
+    # Interactive on purpose: ssh reads the host-key answer and password from
+    # the console. The key is offered first, password is the fallback.
+    & $sshExe -i $KeyPath -o IdentitiesOnly=yes -o ConnectTimeout=15 $target $remoteCmd
+    $installExit = $LASTEXITCODE
+    if ($installExit -ne 0) {
+        Write-Warn ('install command failed (ssh exit {0})' -f $installExit)
+        [void]$results.Add([pscustomobject]@{ Server = $server; Status = 'Failed'; Detail = ('install ssh exit {0}' -f $installExit) })
+        continue
+    }
+
+    if (Test-KeyAuth $sshExe $KeyPath $target) {
+        Write-Host '    verified: key auth works' -ForegroundColor Green
+        [void]$results.Add([pscustomobject]@{ Server = $server; Status = 'Installed'; Detail = '' })
+    }
+    else {
+        Write-Warn 'key was installed but key-based auth still fails'
+        [void]$results.Add([pscustomobject]@{
+                Server = $server
+                Status = 'Failed'
+                Detail = 'verification probe failed; check home dir permissions on the server (no group/other write) and sshd_config AuthorizedKeysFile'
+            })
+    }
+}
+
+# ---- summary -------------------------------------------------------------------
+
+Write-Host ''
+$results | Format-Table -AutoSize -Wrap | Out-Host
+
+$failed = @($results | Where-Object { $_.Status -eq 'Failed' }).Count
+if ($failed -gt 0) {
+    Write-Host ('{0} server(s) failed - fix and re-run (re-runs are safe).' -f $failed) -ForegroundColor Red
+    exit 1
+}
+Write-Host 'All servers ready. You can now run update-fleet.ps1.' -ForegroundColor Green
+exit 0

--- a/scripts/remote/install-ssh-key.ps1
+++ b/scripts/remote/install-ssh-key.ps1
@@ -32,7 +32,7 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$ServerList = (Join-Path $PSScriptRoot 'servers.txt'),
+    [string]$ServerList,
     [string]$User = 'pacefactory',
     [string]$KeyPath = (Join-Path $env:USERPROFILE '.ssh\pf_fleet_ed25519'),
     [switch]$Force
@@ -40,6 +40,15 @@ param(
 
 # Deliberately NOT setting $ErrorActionPreference = 'Stop': in PowerShell 5.1
 # that turns native-command stderr (with 2>&1) into terminating errors.
+
+# $PSScriptRoot can be empty inside a param() default under some PowerShell 5.1
+# invocations (notably -File with a relative path), which made the Join-Path
+# default throw "Cannot bind argument to parameter 'Path'". Resolve the script's
+# own directory here - with a fallback - and fill in any path-based default the
+# caller did not supply.
+$ScriptDir = $PSScriptRoot
+if (-not $ScriptDir) { $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition }
+if (-not $ServerList) { $ServerList = Join-Path $ScriptDir 'servers.txt' }
 
 function Write-Warn([string]$Message) {
     Write-Host ('WARNING: {0}' -f $Message) -ForegroundColor Yellow

--- a/scripts/remote/servers.example.txt
+++ b/scripts/remote/servers.example.txt
@@ -1,0 +1,5 @@
+# Fleet server list: one hostname or IP per line.
+# Lines starting with '#' and blank lines are ignored.
+# Copy this file to servers.txt (servers.txt is gitignored) and edit it.
+site-a.example.com
+192.0.2.10

--- a/scripts/remote/update-fleet.ps1
+++ b/scripts/remote/update-fleet.ps1
@@ -16,12 +16,17 @@
     OpenSSH client is required (no admin rights, no extra software).
     Run install-ssh-key.ps1 once first to set up key-based auth.
 
+    Press Ctrl+C during a run to stop gracefully: the server being updated
+    finishes, the remaining servers are marked SKIPPED, and the summary and
+    per-server logs are still written.
+
     Statuses:
       OK          - updated, all containers up
       WARN        - updated, but something needs attention (non-standard image
                     tags, degraded containers, missing proxy script)
       FAIL        - a step failed on the server (see Detail and the log file)
       UNREACHABLE - ssh could not connect
+      SKIPPED     - not attempted; the run was cancelled with Ctrl+C
 
 .EXAMPLE
     powershell -ExecutionPolicy Bypass -File .\update-fleet.ps1
@@ -129,6 +134,36 @@ function Get-FirstLine([string]$Text) {
         if ($t -ne '') { return $t }
     }
     return ''
+}
+
+# With TreatControlCAsInput enabled, Ctrl+C lands in the console input buffer as
+# an ordinary key event instead of stopping the script. Drain the buffer and
+# report whether a Ctrl+C was among the pending keys.
+function Test-CancelRequested {
+    if (-not $script:CancelEnabled) { return $false }
+    $found = $false
+    try {
+        while ([Console]::KeyAvailable) {
+            $key = [Console]::ReadKey($true)
+            if (($key.Key -eq [ConsoleKey]::C) -and (($key.Modifiers -band [ConsoleModifiers]::Control) -ne 0)) {
+                $found = $true
+            }
+        }
+    }
+    catch { }
+    return $found
+}
+
+# Hand Ctrl+C back to the console (and clear any buffered keystrokes so they do
+# not leak to the parent shell). Safe to call more than once.
+function Restore-CtrlCMode {
+    if (-not $script:CancelEnabled) { return }
+    try {
+        while ([Console]::KeyAvailable) { [void][Console]::ReadKey($true) }
+    }
+    catch { }
+    try { [Console]::TreatControlCAsInput = $false } catch { }
+    $script:CancelEnabled = $false
 }
 
 # Run ssh via System.Diagnostics.Process: no cmd.exe quoting, no PowerShell
@@ -370,10 +405,33 @@ $runStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 $runDir = Join-Path $ReportDir $runStamp
 [void](New-Item -ItemType Directory -Path $runDir -Force)
 
+# Ctrl+C handling: turn Ctrl+C into ordinary console input so it kills neither
+# this script nor the in-flight ssh. We poll for it between servers (see the
+# main loop) and stop gracefully, marking servers we never reached as SKIPPED.
+$script:CancelEnabled = $false
+$script:StopRequested = $false
+try {
+    [Console]::TreatControlCAsInput = $true
+    $script:CancelEnabled = $true
+}
+catch {
+    Write-Warn 'cannot capture Ctrl+C in this console; the run will not be interruptible.'
+}
+
+# Hand Ctrl+C back to the console even on an unexpected terminating error,
+# otherwise the parent shell is left in raw-input mode.
+trap {
+    Restore-CtrlCMode
+    break
+}
+
 $mode = 'update'
 if ($DryRun) { $mode = 'check (dry run)' }
 Write-Host ''
 Write-Host ('Fleet {0}: {1} server(s) as {2}, logs in {3}' -f $mode, $servers.Count, $User, $runDir)
+if ($script:CancelEnabled) {
+    Write-Host '(Press Ctrl+C to stop gracefully after the current server.)' -ForegroundColor DarkGray
+}
 Write-Host ''
 
 # ---- main loop ---------------------------------------------------------------
@@ -381,6 +439,40 @@ Write-Host ''
 $results = New-Object System.Collections.ArrayList
 
 foreach ($server in $servers) {
+    if (-not $script:StopRequested -and (Test-CancelRequested)) {
+        $script:StopRequested = $true
+        Write-Host ''
+        Write-Host 'Cancellation requested (Ctrl+C); skipping remaining servers.' -ForegroundColor Yellow
+    }
+    if ($script:StopRequested) {
+        Write-Host ('--- {0}: SKIPPED (run cancelled)' -f $server) -ForegroundColor DarkYellow
+        [void]$results.Add([pscustomobject]@{
+                Server          = $server
+                Status          = 'SKIPPED'
+                Detail          = 'run cancelled before this server'
+                Containers      = ''
+                CommitBefore    = ''
+                CommitAfter     = ''
+                Behind          = ''
+                ProjectName     = ''
+                NonStandardTags = ''
+                ContainersUp    = ''
+                ContainersTotal = ''
+                Proxy           = ''
+                GitPull         = ''
+                GitFetch        = ''
+                Build           = ''
+                TagScan         = ''
+                Update          = ''
+                Health          = ''
+                PayloadExit     = ''
+                SshExit         = ''
+                DurationSec     = 0
+                LogFile         = ''
+            })
+        continue
+    }
+
     Write-Host ('>>> {0}' -f $server) -ForegroundColor Cyan
     $watch = [System.Diagnostics.Stopwatch]::StartNew()
     $startedAt = Get-Date
@@ -497,10 +589,16 @@ $results |
 $okCount = @($results | Where-Object { $_.Status -eq 'OK' }).Count
 $warnCount = @($results | Where-Object { $_.Status -eq 'WARN' }).Count
 $failCount = @($results | Where-Object { ($_.Status -eq 'FAIL') -or ($_.Status -eq 'UNREACHABLE') }).Count
-Write-Host ('Total: {0}  OK: {1}  WARN: {2}  FAIL/UNREACHABLE: {3}' -f $results.Count, $okCount, $warnCount, $failCount)
+$skipCount = @($results | Where-Object { $_.Status -eq 'SKIPPED' }).Count
+if ($script:StopRequested) {
+    Write-Host ''
+    Write-Host ('Run cancelled (Ctrl+C): {0} server(s) skipped.' -f $skipCount) -ForegroundColor Yellow
+}
+Write-Host ('Total: {0}  OK: {1}  WARN: {2}  FAIL/UNREACHABLE: {3}  SKIPPED: {4}' -f $results.Count, $okCount, $warnCount, $failCount, $skipCount)
 Write-Host ('Logs and summary.csv: {0}' -f $runDir)
 
 $badCount = $failCount
 if ($FailOnWarn) { $badCount = $failCount + $warnCount }
+Restore-CtrlCMode
 if ($badCount -gt 0) { exit 1 }
 exit 0

--- a/scripts/remote/update-fleet.ps1
+++ b/scripts/remote/update-fleet.ps1
@@ -1,0 +1,496 @@
+<#
+.SYNOPSIS
+    Runs the deployment update payload (update-server.sh) on every server in a
+    list, sequentially, over ssh - and prints a per-server summary at the end.
+
+.DESCRIPTION
+    For each server in the list (default: servers.txt next to this script),
+    this script streams update-server.sh to 'bash -s' over ssh using key-based
+    auth, parses the PF|... markers the payload emits, and writes:
+
+      - a per-server log file under <ReportDir>\<timestamp>\
+      - a summary.csv in the same folder
+      - a console summary table
+
+    A failure on one server never stops the run. Only the built-in Windows
+    OpenSSH client is required (no admin rights, no extra software).
+    Run install-ssh-key.ps1 once first to set up key-based auth.
+
+    Statuses:
+      OK          - updated, all containers up
+      WARN        - updated, but something needs attention (non-standard image
+                    tags, degraded containers, missing proxy script)
+      FAIL        - a step failed on the server (see Detail and the log file)
+      UNREACHABLE - ssh could not connect
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\update-fleet.ps1
+
+.EXAMPLE
+    .\update-fleet.ps1 -DryRun
+    Connectivity / pending-changes check only; nothing is modified on servers.
+
+.EXAMPLE
+    .\update-fleet.ps1 -ServerList .\just-one-server.txt -HealthDelaySec 30
+
+.NOTES
+    Exit codes: 0 = all servers OK/WARN, 1 = at least one FAIL/UNREACHABLE,
+    2 = preflight error. With -FailOnWarn, WARN also causes exit 1.
+#>
+[CmdletBinding()]
+param(
+    [string]$ServerList = (Join-Path $PSScriptRoot 'servers.txt'),
+    [string]$User = 'pacefactory',
+    [string]$KeyPath = (Join-Path $env:USERPROFILE '.ssh\pf_fleet_ed25519'),
+    [string]$ReportDir = (Join-Path $PSScriptRoot 'logs'),
+    [int]$ConnectTimeoutSec = 15,
+    [int]$HealthDelaySec = 15,
+    [switch]$DryRun,
+    [switch]$FailOnWarn,
+    [switch]$Quiet,
+    [ValidateSet('accept-new', 'yes', 'no')]
+    [string]$HostKeyPolicy = 'accept-new'
+)
+
+# Deliberately NOT setting $ErrorActionPreference = 'Stop': in PowerShell 5.1
+# that turns native-command stderr (with 2>&1) into terminating errors.
+
+function Write-Warn([string]$Message) {
+    Write-Host ('WARNING: {0}' -f $Message) -ForegroundColor Yellow
+}
+
+function Fail-Preflight([string]$Message) {
+    Write-Host ('ERROR: {0}' -f $Message) -ForegroundColor Red
+    exit 2
+}
+
+# Locate ssh.exe; PATH first, then the standard Windows OpenSSH location
+# (locked-down machines sometimes omit it from PATH).
+function Resolve-SshExe {
+    $cmd = Get-Command 'ssh.exe' -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $fallback = Join-Path $env:WINDIR 'System32\OpenSSH\ssh.exe'
+    if (Test-Path -LiteralPath $fallback) { return $fallback }
+    return $null
+}
+
+# StrictHostKeyChecking=accept-new needs OpenSSH 7.6+ (every supported
+# Windows 10/11 build ships 7.7+). Returns $true when the version is fine.
+function Test-SshSupportsAcceptNew([string]$SshExe) {
+    $verText = ''
+    try { $verText = (& $SshExe -V 2>&1 | Out-String) } catch { $verText = '' }
+    if ($verText -match 'OpenSSH_(\d+)\.(\d+)') {
+        $major = [int]$Matches[1]
+        $minor = [int]$Matches[2]
+        if ($major -gt 7) { return $true }
+        if (($major -eq 7) -and ($minor -ge 6)) { return $true }
+        return $false
+    }
+    return $false
+}
+
+function Read-ServerList([string]$Path) {
+    $servers = New-Object System.Collections.ArrayList
+    $seen = @{}
+    foreach ($raw in @(Get-Content -LiteralPath $Path)) {
+        $line = ('{0}' -f $raw).Trim()
+        if ($line -eq '') { continue }
+        if ($line.StartsWith('#')) { continue }
+        # Hostname/IP only; anything else could smuggle extra ssh arguments.
+        if ($line -notmatch '^[A-Za-z0-9.:_-]+$') {
+            Write-Warn ('skipping invalid server entry: "{0}"' -f $line)
+            continue
+        }
+        $key = $line.ToLowerInvariant()
+        if ($seen.ContainsKey($key)) {
+            Write-Warn ('duplicate server "{0}" - skipping repeat' -f $line)
+            continue
+        }
+        $seen[$key] = $true
+        [void]$servers.Add($line)
+    }
+    return , $servers
+}
+
+function Get-FirstLine([string]$Text) {
+    if ($null -eq $Text) { return '' }
+    foreach ($line in $Text -split "`r?`n") {
+        $t = $line.Trim()
+        if ($t -ne '') { return $t }
+    }
+    return ''
+}
+
+# Run ssh via System.Diagnostics.Process: no cmd.exe quoting, no PowerShell
+# re-encoding of the pipeline, and native stderr stays a plain string instead
+# of becoming ErrorRecords.
+function Invoke-SshPayload {
+    param(
+        [string]$SshExe,
+        [string]$ArgumentString,
+        [string]$PayloadText,
+        [string]$Server,
+        [bool]$ShowLive
+    )
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $SshExe
+    $psi.Arguments = $ArgumentString
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.StandardOutputEncoding = New-Object System.Text.UTF8Encoding $false
+    $psi.StandardErrorEncoding = New-Object System.Text.UTF8Encoding $false
+
+    $proc = New-Object System.Diagnostics.Process
+    $proc.StartInfo = $psi
+
+    $stdoutLines = New-Object System.Collections.ArrayList
+    $stderrText = ''
+    $exitCode = -1
+
+    try {
+        [void]$proc.Start()
+
+        # Drain stderr asynchronously so neither pipe can fill up and stall ssh.
+        $errTask = $proc.StandardError.ReadToEndAsync()
+
+        try {
+            $proc.StandardInput.Write($PayloadText)
+            $proc.StandardInput.Close()
+        }
+        catch {
+            # ssh exited before consuming stdin (e.g. unreachable host);
+            # the exit code and stderr tell the real story.
+        }
+
+        while ($null -ne ($line = $proc.StandardOutput.ReadLine())) {
+            [void]$stdoutLines.Add($line)
+            if ($ShowLive) { Write-Host ('[{0}] {1}' -f $Server, $line) }
+        }
+
+        $proc.WaitForExit()
+        $exitCode = $proc.ExitCode
+        $stderrText = $errTask.Result
+    }
+    finally {
+        # HasExited itself throws if the process never started.
+        try {
+            if (-not $proc.HasExited) { $proc.Kill() }
+        }
+        catch { }
+        $proc.Dispose()
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Stdout   = $stdoutLines
+        Stderr   = $stderrText
+    }
+}
+
+# Parse the PF|... marker lines out of the payload's stdout.
+function ConvertFrom-Markers {
+    param($Lines)
+
+    $m = @{
+        Begin       = $false
+        End         = $false
+        PayloadExit = ''
+        Steps       = @{}
+        Tags        = New-Object System.Collections.ArrayList
+        Health      = New-Object System.Collections.ArrayList
+        Info        = @{}
+    }
+
+    foreach ($raw in $Lines) {
+        $t = ('{0}' -f $raw).Trim()
+        if (-not $t.StartsWith('PF|')) { continue }
+        $f = $t.Split('|')
+        if ($f.Count -lt 2) { continue }
+        switch ($f[1]) {
+            'BEGIN' { $m.Begin = $true }
+            'END' {
+                $m.End = $true
+                if ($f.Count -ge 3) { $m.PayloadExit = $f[2] }
+            }
+            'STEP' {
+                if ($f.Count -ge 4) {
+                    $rc = 0
+                    if ([int]::TryParse($f[3], [ref]$rc)) { $m.Steps[$f[2]] = $rc }
+                }
+            }
+            'TAG' {
+                if ($f.Count -ge 3) { [void]$m.Tags.Add($f[2]) }
+            }
+            'HEALTH' {
+                if ($f.Count -ge 4) { [void]$m.Health.Add(('{0} [{1}]' -f $f[2], $f[3])) }
+            }
+            'INFO' {
+                if ($f.Count -ge 4) { $m.Info[$f[2]] = $f[3] }
+            }
+            default { }
+        }
+    }
+    return $m
+}
+
+function Get-StepRc($Marks, [string]$Name) {
+    if ($Marks.Steps.ContainsKey($Name)) { return $Marks.Steps[$Name] }
+    return ''
+}
+
+function Get-InfoValue($Marks, [string]$Name) {
+    if ($Marks.Info.ContainsKey($Name)) { return $Marks.Info[$Name] }
+    return ''
+}
+
+# Decide OK / WARN / FAIL / UNREACHABLE for one server.
+function Get-ServerStatus {
+    param($Marks, [int]$SshExit, [string]$StderrText, [bool]$IsDryRun)
+
+    if (-not $Marks.Begin) {
+        if ($SshExit -eq 255) {
+            $reason = Get-FirstLine $StderrText
+            if ($reason -eq '') { $reason = 'ssh connection failed' }
+            return [pscustomobject]@{ Status = 'UNREACHABLE'; Detail = $reason }
+        }
+        return [pscustomobject]@{ Status = 'FAIL'; Detail = ('no payload output (ssh exit code {0})' -f $SshExit) }
+    }
+    if (-not $Marks.End) {
+        return [pscustomobject]@{ Status = 'FAIL'; Detail = 'connection lost mid-run (no END marker)' }
+    }
+
+    foreach ($step in @('repo', 'git_pull', 'build', 'update')) {
+        $rc = Get-StepRc $Marks $step
+        if (($rc -ne '') -and ($rc -ne 0)) {
+            $note = ''
+            if ($rc -eq 124) { $note = ' (timed out)' }
+            return [pscustomobject]@{ Status = 'FAIL'; Detail = ("step '{0}' failed with rc {1}{2}" -f $step, $rc, $note) }
+        }
+    }
+    if ((Get-StepRc $Marks 'health') -eq 1) {
+        return [pscustomobject]@{ Status = 'FAIL'; Detail = 'no containers found (deployment absent or docker down)' }
+    }
+
+    $warns = @()
+    if ($Marks.Tags.Count -gt 0) {
+        $warns += ('{0} non-standard tag(s)' -f $Marks.Tags.Count)
+    }
+    $healthRc = Get-StepRc $Marks 'health'
+    if (($healthRc -ne '') -and ($healthRc -ge 2)) {
+        $warns += ('degraded: {0}' -f ($Marks.Health -join ', '))
+    }
+    $proxyRc = Get-StepRc $Marks 'proxy'
+    if (($proxyRc -ne '') -and ($proxyRc -ne 0)) {
+        $warns += 'proxy script missing or failed'
+    }
+    $fetchRc = Get-StepRc $Marks 'git_fetch'
+    if (($fetchRc -ne '') -and ($fetchRc -ne 0)) {
+        $warns += 'git fetch failed'
+    }
+    if ($IsDryRun) {
+        $behind = Get-InfoValue $Marks 'behind'
+        if (($behind -ne '') -and ($behind -ne '0') -and ($behind -ne 'unknown')) {
+            $warns += ('{0} commit(s) behind origin' -f $behind)
+        }
+    }
+    if ($warns.Count -gt 0) {
+        return [pscustomobject]@{ Status = 'WARN'; Detail = ($warns -join '; ') }
+    }
+
+    $detail = 'ok'
+    $before = Get-InfoValue $Marks 'commit_before'
+    $after = Get-InfoValue $Marks 'commit_after'
+    if ($IsDryRun) {
+        $detail = 'reachable, up to date'
+    }
+    elseif (($before -ne '') -and ($after -ne '')) {
+        if ($before -eq $after) { $detail = ('already on {0}' -f $after) }
+        else { $detail = ('updated {0} -> {1}' -f $before, $after) }
+    }
+    return [pscustomobject]@{ Status = 'OK'; Detail = $detail }
+}
+
+# ---- preflight ---------------------------------------------------------------
+
+$sshExe = Resolve-SshExe
+if (-not $sshExe) {
+    Fail-Preflight 'ssh.exe not found. The built-in Windows OpenSSH client is required (Windows 10 1809+ / Windows 11).'
+}
+
+if (-not (Test-SshSupportsAcceptNew $sshExe)) {
+    if ($HostKeyPolicy -eq 'accept-new') {
+        Write-Warn 'could not confirm this OpenSSH supports StrictHostKeyChecking=accept-new (needs 7.6+).'
+        Write-Warn 'if connections fail with "Bad configuration option", rerun with -HostKeyPolicy yes'
+        Write-Warn '(install-ssh-key.ps1 already added the host keys to known_hosts, so "yes" is safe).'
+    }
+}
+
+if (-not (Test-Path -LiteralPath $ServerList)) {
+    Fail-Preflight ('server list not found: {0} (copy servers.example.txt to servers.txt and edit it)' -f $ServerList)
+}
+if (-not (Test-Path -LiteralPath $KeyPath)) {
+    Fail-Preflight ('ssh key not found: {0} (run install-ssh-key.ps1 first)' -f $KeyPath)
+}
+$payloadPath = Join-Path $PSScriptRoot 'update-server.sh'
+if (-not (Test-Path -LiteralPath $payloadPath)) {
+    Fail-Preflight ('payload not found: {0}' -f $payloadPath)
+}
+
+$servers = Read-ServerList $ServerList
+if ($servers.Count -eq 0) {
+    Fail-Preflight ('no servers found in {0}' -f $ServerList)
+}
+
+# The payload is ASCII; normalizing line endings here makes the run safe even
+# if the file was checked out (or edited) with CRLF.
+$payloadText = [System.IO.File]::ReadAllText($payloadPath)
+$payloadText = $payloadText -replace "`r`n", "`n"
+$payloadText = $payloadText -replace "`r", "`n"
+
+try {
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+}
+catch { }
+
+$runStamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$runDir = Join-Path $ReportDir $runStamp
+[void](New-Item -ItemType Directory -Path $runDir -Force)
+
+$mode = 'update'
+if ($DryRun) { $mode = 'check (dry run)' }
+Write-Host ''
+Write-Host ('Fleet {0}: {1} server(s) as {2}, logs in {3}' -f $mode, $servers.Count, $User, $runDir)
+Write-Host ''
+
+# ---- main loop ---------------------------------------------------------------
+
+$results = New-Object System.Collections.ArrayList
+
+foreach ($server in $servers) {
+    Write-Host ('>>> {0}' -f $server) -ForegroundColor Cyan
+    $watch = [System.Diagnostics.Stopwatch]::StartNew()
+    $startedAt = Get-Date
+
+    $remoteArgs = @('bash', '-s', '--')
+    if ($DryRun) { $remoteArgs += '--check' }
+    else { $remoteArgs += @('--health-delay', ('{0}' -f $HealthDelaySec)) }
+
+    $keyArg = $KeyPath
+    if ($keyArg -match '\s') { $keyArg = ('"{0}"' -f $keyArg) }
+    $sshArgs = @(
+        '-i', $keyArg,
+        '-o', 'IdentitiesOnly=yes',
+        '-o', 'BatchMode=yes',
+        '-o', ('ConnectTimeout={0}' -f $ConnectTimeoutSec),
+        '-o', ('StrictHostKeyChecking={0}' -f $HostKeyPolicy),
+        '-o', 'ServerAliveInterval=15',
+        '-o', 'ServerAliveCountMax=3',
+        '-T',
+        ('{0}@{1}' -f $User, $server)
+    ) + $remoteArgs
+
+    $sshExit = -1
+    $stdout = @()
+    $stderrText = ''
+    $marks = ConvertFrom-Markers @()
+    $verdict = $null
+
+    try {
+        $run = Invoke-SshPayload -SshExe $sshExe -ArgumentString ($sshArgs -join ' ') `
+            -PayloadText $payloadText -Server $server -ShowLive (-not $Quiet)
+        $sshExit = $run.ExitCode
+        $stdout = $run.Stdout
+        $stderrText = $run.Stderr
+        $marks = ConvertFrom-Markers $stdout
+        $verdict = Get-ServerStatus -Marks $marks -SshExit $sshExit -StderrText $stderrText -IsDryRun ([bool]$DryRun)
+    }
+    catch {
+        $verdict = [pscustomobject]@{ Status = 'FAIL'; Detail = ('orchestrator error: {0}' -f $_.Exception.Message) }
+    }
+
+    $watch.Stop()
+
+    # Per-server log file.
+    $safeName = ($server -replace '[^A-Za-z0-9._-]', '_')
+    $logFile = Join-Path $runDir ('{0}.log' -f $safeName)
+    $logParts = New-Object System.Collections.ArrayList
+    [void]$logParts.Add(('server   : {0}' -f $server))
+    [void]$logParts.Add(('started  : {0}' -f $startedAt.ToString('yyyy-MM-dd HH:mm:ss')))
+    [void]$logParts.Add(('duration : {0}s' -f [int]$watch.Elapsed.TotalSeconds))
+    [void]$logParts.Add(('ssh exit : {0}' -f $sshExit))
+    [void]$logParts.Add(('status   : {0} - {1}' -f $verdict.Status, $verdict.Detail))
+    [void]$logParts.Add('')
+    [void]$logParts.Add('--- remote output ---')
+    foreach ($line in $stdout) { [void]$logParts.Add($line) }
+    [void]$logParts.Add('')
+    [void]$logParts.Add('--- ssh stderr ---')
+    [void]$logParts.Add(('{0}' -f $stderrText))
+    ($logParts -join [Environment]::NewLine) | Out-File -FilePath $logFile -Encoding utf8
+
+    $containersUp = Get-InfoValue $marks 'containers_up'
+    $containersTotal = Get-InfoValue $marks 'containers_total'
+    $containers = ''
+    if ($containersTotal -ne '') { $containers = ('{0}/{1}' -f $containersUp, $containersTotal) }
+
+    $result = [pscustomobject]@{
+        Server          = $server
+        Status          = $verdict.Status
+        Detail          = $verdict.Detail
+        Containers      = $containers
+        CommitBefore    = Get-InfoValue $marks 'commit_before'
+        CommitAfter     = Get-InfoValue $marks 'commit_after'
+        Behind          = Get-InfoValue $marks 'behind'
+        ProjectName     = Get-InfoValue $marks 'project_name'
+        NonStandardTags = ($marks.Tags -join '; ')
+        ContainersUp    = $containersUp
+        ContainersTotal = $containersTotal
+        Proxy           = Get-StepRc $marks 'proxy'
+        GitPull         = Get-StepRc $marks 'git_pull'
+        GitFetch        = Get-StepRc $marks 'git_fetch'
+        Build           = Get-StepRc $marks 'build'
+        TagScan         = Get-StepRc $marks 'tag_scan'
+        Update          = Get-StepRc $marks 'update'
+        Health          = Get-StepRc $marks 'health'
+        PayloadExit     = $marks.PayloadExit
+        SshExit         = $sshExit
+        DurationSec     = [int]$watch.Elapsed.TotalSeconds
+        LogFile         = $logFile
+    }
+    [void]$results.Add($result)
+
+    $color = 'Green'
+    if ($verdict.Status -eq 'WARN') { $color = 'Yellow' }
+    if (($verdict.Status -eq 'FAIL') -or ($verdict.Status -eq 'UNREACHABLE')) { $color = 'Red' }
+    Write-Host ('<<< {0}: {1} - {2}' -f $server, $verdict.Status, $verdict.Detail) -ForegroundColor $color
+    Write-Host ''
+}
+
+# ---- summary -----------------------------------------------------------------
+
+$csvPath = Join-Path $runDir 'summary.csv'
+$results |
+    Select-Object Server, Status, Detail, CommitBefore, CommitAfter, Behind, ProjectName,
+        NonStandardTags, ContainersUp, ContainersTotal, Proxy, GitPull, GitFetch, Build,
+        TagScan, Update, Health, PayloadExit, SshExit, DurationSec, LogFile |
+    Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
+
+Write-Host '==================== SUMMARY ====================' -ForegroundColor Cyan
+$results |
+    Select-Object Server, Status, Containers, @{ Name = 'Tags'; Expression = { $_.NonStandardTags } }, DurationSec, Detail |
+    Format-Table -AutoSize -Wrap |
+    Out-Host
+
+$okCount = @($results | Where-Object { $_.Status -eq 'OK' }).Count
+$warnCount = @($results | Where-Object { $_.Status -eq 'WARN' }).Count
+$failCount = @($results | Where-Object { ($_.Status -eq 'FAIL') -or ($_.Status -eq 'UNREACHABLE') }).Count
+Write-Host ('Total: {0}  OK: {1}  WARN: {2}  FAIL/UNREACHABLE: {3}' -f $results.Count, $okCount, $warnCount, $failCount)
+Write-Host ('Logs and summary.csv: {0}' -f $runDir)
+
+$badCount = $failCount
+if ($FailOnWarn) { $badCount = $failCount + $warnCount }
+if ($badCount -gt 0) { exit 1 }
+exit 0

--- a/scripts/remote/update-fleet.ps1
+++ b/scripts/remote/update-fleet.ps1
@@ -39,10 +39,10 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$ServerList = (Join-Path $PSScriptRoot 'servers.txt'),
+    [string]$ServerList,
     [string]$User = 'pacefactory',
     [string]$KeyPath = (Join-Path $env:USERPROFILE '.ssh\pf_fleet_ed25519'),
-    [string]$ReportDir = (Join-Path $PSScriptRoot 'logs'),
+    [string]$ReportDir,
     [int]$ConnectTimeoutSec = 15,
     [int]$HealthDelaySec = 15,
     [switch]$DryRun,
@@ -54,6 +54,16 @@ param(
 
 # Deliberately NOT setting $ErrorActionPreference = 'Stop': in PowerShell 5.1
 # that turns native-command stderr (with 2>&1) into terminating errors.
+
+# $PSScriptRoot can be empty inside a param() default under some PowerShell 5.1
+# invocations (notably -File with a relative path), which made the Join-Path
+# defaults throw "Cannot bind argument to parameter 'Path'". Resolve the script's
+# own directory here - with a fallback - and fill in any path-based defaults the
+# caller did not supply.
+$ScriptDir = $PSScriptRoot
+if (-not $ScriptDir) { $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition }
+if (-not $ServerList) { $ServerList = Join-Path $ScriptDir 'servers.txt' }
+if (-not $ReportDir) { $ReportDir = Join-Path $ScriptDir 'logs' }
 
 function Write-Warn([string]$Message) {
     Write-Host ('WARNING: {0}' -f $Message) -ForegroundColor Yellow
@@ -335,7 +345,7 @@ if (-not (Test-Path -LiteralPath $ServerList)) {
 if (-not (Test-Path -LiteralPath $KeyPath)) {
     Fail-Preflight ('ssh key not found: {0} (run install-ssh-key.ps1 first)' -f $KeyPath)
 }
-$payloadPath = Join-Path $PSScriptRoot 'update-server.sh'
+$payloadPath = Join-Path $ScriptDir 'update-server.sh'
 if (-not (Test-Path -LiteralPath $payloadPath)) {
     Fail-Preflight ('payload not found: {0}' -f $payloadPath)
 }

--- a/scripts/remote/update-server.sh
+++ b/scripts/remote/update-server.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+#
+# update-server.sh - per-server update payload for the fleet update tooling.
+#
+# Normally streamed over ssh stdin by update-fleet.ps1:
+#
+#   ssh <user>@<host> bash -s -- [--check] [--health-delay N] < update-server.sh
+#
+# It can also be run directly on a server for debugging:
+#
+#   bash update-server.sh [--check] [--health-delay N]
+#
+# Everything is wrapped in functions so bash reads the whole script before
+# executing anything, and main runs with stdin redirected from /dev/null so
+# no remote command can consume the rest of the streamed script.
+#
+# Machine-readable markers (all other output is normal passthrough):
+#
+#   PF|BEGIN|v1|<hostname>|<epoch>
+#   PF|INFO|<key>|<value>
+#   PF|STEP|<step>|<rc>|<duration_sec>   steps: proxy repo git_pull git_fetch
+#                                               build tag_scan update health
+#   PF|TAG|<image_ref>                   pacefactory image not on latest/latest-gpu
+#   PF|HEALTH|<container>|<status>       one per container that is not Up/healthy
+#   PF|END|<exit_code>
+#
+# Exit codes:
+#   0   success (warnings, if any, are carried by the markers)
+#   11  repo directory missing
+#   12  git pull failed
+#   13  build.sh failed or produced an invalid docker-compose.yml
+#   14  update.sh failed (or never reported "Deployment complete")
+#   15  health check found no containers (deployment absent or docker down)
+#   16  health check found degraded containers
+#
+# A step rc of 124 means the step was killed by its timeout.
+
+REPO_DIR="$HOME/scv2/git_clones/deployment-scripts"
+PROXY_SCRIPT="$HOME/connect-to-proxy.sh"
+HEALTH_DELAY=15
+CHECK_MODE=false
+LAST_RC=0
+
+# ---- marker helpers --------------------------------------------------------
+
+# Emit one marker line. The leading newline guarantees the marker starts at
+# column 0 even if a previous command left a partial line on stdout.
+pf_marker() {
+  local IFS='|'
+  printf '\nPF|%s\n' "$*"
+}
+
+# Sanitize free text destined for a marker field: no CRs, no pipes.
+pf_clean() {
+  tr -d '\r' | tr '|' '/'
+}
+
+# Run a step function, record its rc in LAST_RC and emit the STEP marker.
+#   run_step <marker_name> <function> [args...]
+run_step() {
+  local name="$1"
+  shift
+  local start=$SECONDS
+  "$@"
+  LAST_RC=$?
+  pf_marker STEP "$name" "$LAST_RC" "$((SECONDS - start))"
+  return "$LAST_RC"
+}
+
+# ---- steps -----------------------------------------------------------------
+
+step_proxy() {
+  if [[ ! -f "$PROXY_SCRIPT" ]]; then
+    echo "proxy: $PROXY_SCRIPT not found, continuing without it"
+    return 3
+  fi
+  # Sourced (not executed) so the proxy environment variables persist for the
+  # git/docker steps below.
+  source "$PROXY_SCRIPT"
+}
+
+step_repo() {
+  cd "$REPO_DIR" || { echo "repo: cannot cd to $REPO_DIR"; return 1; }
+}
+
+step_git_pull() {
+  pf_marker INFO commit_before "$(git rev-parse --short HEAD 2>/dev/null | pf_clean)"
+  GIT_TERMINAL_PROMPT=0 timeout 600 git pull --ff-only
+  local rc=$?
+  pf_marker INFO commit_after "$(git rev-parse --short HEAD 2>/dev/null | pf_clean)"
+  return "$rc"
+}
+
+step_git_fetch() {
+  GIT_TERMINAL_PROMPT=0 timeout 120 git fetch
+  local rc=$?
+  local behind
+  behind="$(git rev-list --count 'HEAD..@{u}' 2>/dev/null)"
+  pf_marker INFO behind "${behind:-unknown}"
+  return "$rc"
+}
+
+step_build() {
+  timeout 900 ./build.sh -q
+  local rc=$?
+  # build.sh does not check the exit code of 'docker compose config', which
+  # truncates docker-compose.yml on failure while build.sh still exits 0.
+  # Trust the generated file, not the exit code.
+  if [[ ! -s docker-compose.yml ]] || ! grep -q '^services:' docker-compose.yml; then
+    echo "build: docker-compose.yml is missing, empty or has no services section"
+    [[ "$rc" -eq 0 ]] && rc=1
+  fi
+  return "$rc"
+}
+
+# Print a PF|TAG line for every pacefactory image in the resolved compose file
+# whose tag is not latest/latest-gpu (digest pins count as non-standard).
+# Third-party images (mongo, nodered, ...) are ignored on purpose.
+scan_tags() {
+  awk '
+    $1 == "image:" {
+      ref = $2
+      gsub(/^["\047]|["\047]$/, "", ref)
+      if (ref !~ "(^|/)pacefactory/") next
+      if (index(ref, "@") > 0) { print "PF|TAG|" ref; next }
+      n = split(ref, p, "/")
+      last = p[n]
+      tag = (index(last, ":") > 0) ? substr(last, index(last, ":") + 1) : "latest"
+      if (tag != "latest" && tag != "latest-gpu") print "PF|TAG|" ref
+    }
+  ' "$1"
+}
+
+step_tag_scan() {
+  local file="docker-compose.yml"
+  local tags="" count=0
+  if [[ ! -f "$file" ]]; then
+    echo "tag_scan: no $file here yet, skipping"
+  else
+    tags="$(scan_tags "$file")"
+  fi
+  if [[ -n "$tags" ]]; then
+    count="$(printf '%s\n' "$tags" | grep -c '^PF|TAG|')"
+    printf '\n%s\n' "$tags"
+  fi
+  pf_marker INFO nonstandard_tags "$count"
+  return 0
+}
+
+step_update() {
+  local tmp rc
+  tmp="$(mktemp)" || return 1
+  timeout 3600 ./update.sh -q 2>&1 | tee "$tmp"
+  rc="${PIPESTATUS[0]}"
+  # update.sh exits 0 even when the image pull fails (the up/migration block
+  # is silently skipped in that case). "Deployment complete" only prints on
+  # the success path, so use it as the success sentinel.
+  if [[ "$rc" -eq 0 ]] && ! grep -q "Deployment complete" "$tmp"; then
+    echo "update: update.sh exited 0 but never reported 'Deployment complete' (pull likely failed)"
+    rc=21
+  fi
+  rm -f "$tmp"
+  return "$rc"
+}
+
+# Derive the compose project name the same way update.sh does, in a subshell
+# so nothing leaks into the payload environment.
+get_project_name() {
+  (
+    QUIET_MODE=true
+    [[ -f .settings ]] && . .settings >/dev/null 2>&1
+    [[ -f scripts/common/projectName.sh ]] && . scripts/common/projectName.sh >/dev/null 2>&1
+    printf '%s' "${PROJECT_NAME:-deployment-scripts}"
+  )
+}
+
+step_health() {
+  local delay="$1"
+  if [[ "$delay" -gt 0 ]]; then
+    echo "health: waiting ${delay}s for containers to settle"
+    sleep "$delay"
+  fi
+
+  local project
+  project="$(get_project_name)"
+  pf_marker INFO project_name "$(printf '%s' "$project" | pf_clean)"
+
+  local ps_out
+  if ! ps_out="$(docker ps -a --filter "label=com.docker.compose.project=$project" --format '{{.Names}}\t{{.Status}}' 2>&1)"; then
+    echo "health: docker ps failed: $ps_out"
+    pf_marker INFO containers_up 0
+    pf_marker INFO containers_total 0
+    return 1
+  fi
+
+  local total=0 up=0 name status
+  while IFS=$'\t' read -r name status; do
+    [[ -z "$name" ]] && continue
+    total=$((total + 1))
+    if [[ "$status" == Up* && "$status" != *"(unhealthy)"* ]]; then
+      up=$((up + 1))
+    else
+      pf_marker HEALTH "$(printf '%s' "$name" | pf_clean)" "$(printf '%s' "$status" | pf_clean)"
+    fi
+  done <<< "$ps_out"
+
+  pf_marker INFO containers_up "$up"
+  pf_marker INFO containers_total "$total"
+  echo "health: $up/$total containers up"
+
+  [[ "$total" -eq 0 ]] && return 1
+  [[ "$up" -lt "$total" ]] && return 2
+  return 0
+}
+
+# ---- modes -----------------------------------------------------------------
+
+main_update() {
+  run_step proxy step_proxy                  # warning only, never aborts
+  run_step repo step_repo || return 11
+  run_step git_pull step_git_pull || return 12
+  run_step build step_build || return 13
+  run_step tag_scan step_tag_scan            # report only, never aborts
+
+  run_step update step_update
+  local update_rc="$LAST_RC"
+
+  run_step health step_health "$HEALTH_DELAY"
+  local health_rc="$LAST_RC"
+
+  [[ "$update_rc" -ne 0 ]] && return 14
+  [[ "$health_rc" -eq 1 ]] && return 15
+  [[ "$health_rc" -ge 2 ]] && return 16
+  return 0
+}
+
+# Read-only preflight: connectivity, pending commits, current tags and health.
+main_check() {
+  run_step proxy step_proxy
+  run_step repo step_repo || return 11
+  pf_marker INFO branch "$(git rev-parse --abbrev-ref HEAD 2>/dev/null | pf_clean)"
+  pf_marker INFO commit_before "$(git rev-parse --short HEAD 2>/dev/null | pf_clean)"
+  run_step git_fetch step_git_fetch
+  run_step tag_scan step_tag_scan
+  run_step health step_health 0
+  return 0
+}
+
+main() {
+  # One ordered output stream; ssh's own (local) stderr stays separate so the
+  # orchestrator can tell transport problems from payload output.
+  exec 2>&1
+
+  local mode="update"
+  [[ "$CHECK_MODE" == "true" ]] && mode="check"
+
+  pf_marker BEGIN v1 "$(hostname | pf_clean)" "$(date +%s)"
+  pf_marker INFO mode "$mode"
+
+  if [[ "$mode" == "check" ]]; then
+    main_check
+  else
+    main_update
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --check)
+        CHECK_MODE=true
+        ;;
+      --health-delay)
+        shift
+        HEALTH_DELAY="${1:-15}"
+        ;;
+      *)
+        echo "update-server.sh: ignoring unknown argument '$1'" >&2
+        ;;
+    esac
+    shift 2>/dev/null || break
+  done
+  [[ "$HEALTH_DELAY" =~ ^[0-9]+$ ]] || HEALTH_DELAY=15
+}
+
+# ---- entry point -----------------------------------------------------------
+
+# Offline test hook: print the PF|TAG lines for a given compose file and exit.
+if [[ "${1:-}" == "--selftest-tagscan" ]]; then
+  scan_tags "${2:?usage: --selftest-tagscan <compose-file>}"
+  exit 0
+fi
+
+parse_args "$@"
+main </dev/null
+rc=$?
+pf_marker END "$rc"
+exit "$rc"

--- a/update.sh
+++ b/update.sh
@@ -85,6 +85,11 @@ then
     NEEDS_LOGOUT=true
 
     pull_command="docker compose --project-name $PROJECT_NAME pull"
+    # In quiet mode, suppress the per-layer pull progress (very noisy without a TTY, e.g. over ssh).
+    if [[ "$QUIET_MODE" == "true" ]];
+    then
+        pull_command="$pull_command --quiet"
+    fi
     echo $pull_command
 
     if $pull_command;


### PR DESCRIPTION
## Summary

Adds a complete suite of PowerShell and Bash scripts to enable semi-automated fleet updates across multiple deployment servers from a Windows machine, using only the built-in OpenSSH client.

## Key Changes

- **`scripts/remote/update-fleet.ps1`**: Main orchestrator script that:
  - Reads a server list and connects to each via ssh with key-based auth
  - Streams the update payload (`update-server.sh`) to each server sequentially
  - Parses machine-readable markers from the payload output
  - Generates per-server logs and a summary CSV with detailed status information
  - Reports OK/WARN/FAIL/UNREACHABLE status for each server
  - Supports dry-run mode for preflight checks without modifications

- **`scripts/remote/update-server.sh`**: Per-server payload that:
  - Runs `git pull --ff-only`, `build.sh -q`, and `update.sh -q` in sequence
  - Scans the resolved compose file for non-standard pacefactory image tags
  - Performs health checks on deployed containers
  - Emits structured `PF|...` markers for orchestrator parsing
  - Supports `--check` mode for read-only connectivity/status verification
  - Includes timeout protection and detailed error reporting

- **`scripts/remote/install-ssh-key.ps1`**: One-time setup script that:
  - Creates a dedicated ed25519 ssh key (if needed)
  - Installs the public key on each server via interactive ssh
  - Verifies key-based auth works before and after installation
  - Handles SELinux label restoration on RHEL systems
  - Is idempotent and safe to re-run

- **`scripts/remote/servers.example.txt`**: Template for the server list configuration

- **`scripts/remote/README.md`**: Comprehensive documentation covering:
  - Prerequisites and setup instructions
  - Usage examples and command-line options
  - Detailed explanation of what each run does
  - Output format and status meanings
  - Troubleshooting guide

- **`.gitattributes`**: Enforces LF line endings for shell scripts to prevent CRLF corruption when streamed over ssh from Windows checkouts

- **`.gitignore`**: Adds entries for `scripts/remote/servers.txt` (user-specific) and `scripts/remote/logs/` (runtime artifacts)

- **`README.md`**: Added section linking to the new remote fleet update tooling

## Notable Implementation Details

- Uses `System.Diagnostics.Process` in PowerShell to avoid cmd.exe quoting issues and preserve stderr as plain text
- Streams the payload directly over ssh stdin rather than copying files, keeping the deployment footprint minimal
- Parses structured markers (`PF|BEGIN`, `PF|STEP`, `PF|TAG`, `PF|HEALTH`, `PF|INFO`, `PF|END`) to extract machine-readable results from normal command output
- Handles both standard and degraded container states independently of script exit codes
- Supports configurable health check delays and connection timeouts
- Generates timestamped run directories with per-server logs and CSV summaries for audit trails
- Requires no admin rights or third-party software on Windows; works with PowerShell 5.1+

https://claude.ai/code/session_01CqEBdnHQubEYEVejc95XnR