### PR TITLE
Validate project names and reject invalid Docker Compose names

### DIFF
--- a/scripts/common/projectName.sh
+++ b/scripts/common/projectName.sh
@@ -3,13 +3,45 @@ CURRENT_PROJECT=$(docker compose ls --all --quiet | head -1)
 CURRENT_PROJECT=${CURRENT_PROJECT:-$DEFAULT_PROJECT}
 PROJECT_NAME=${PROJECT_NAME:-$CURRENT_PROJECT}
 
+# Docker Compose only accepts project names made up of lowercase letters,
+# digits, dashes and underscores that begin with a letter or digit. Anything
+# else (for example a name containing spaces or uppercase letters) either makes
+# the `docker compose --project-name $PROJECT_NAME ...` calls fail outright or
+# splits into broken arguments. Reject invalid names here so we never generate a
+# broken deployment later on.
+project_name_is_valid() {
+  [[ "$1" =~ ^[a-z0-9][a-z0-9_-]*$ ]]
+}
+
+warn_invalid_project_name() {
+  echo >&2 "Invalid project name: '$1'"
+  echo >&2 "Project names must consist only of lowercase letters (a-z), digits (0-9),"
+  echo >&2 "dashes (-) and underscores (_), and must start with a letter or digit"
+  echo >&2 "(no spaces or other characters)."
+}
+
 if [[ -z $QUIET_MODE ]];
-then 
-  read -r -p "Confirm project name [${PROJECT_NAME}]: "
-  if [[ ! -z "$REPLY" ]];
-  then
-      PROJECT_NAME=$REPLY
-  fi;
+then
+  # Re-prompt until a valid name is entered. Using `while read` means the loop
+  # also terminates on EOF (e.g. Ctrl-D) instead of spinning forever, and the
+  # final guard below catches any still-invalid value.
+  while read -r -p "Confirm project name [${PROJECT_NAME}]: "; do
+    # An empty reply keeps the currently proposed name.
+    candidate="${REPLY:-$PROJECT_NAME}"
+    if project_name_is_valid "$candidate"; then
+      PROJECT_NAME="$candidate"
+      break
+    fi
+    warn_invalid_project_name "$candidate"
+  done
+fi
+
+# Final guard covering every source of the name: quiet mode, a value supplied
+# via -n/--name, a value restored from .settings, and the interactive prompt
+# hitting EOF. Never proceed with a name Docker Compose will reject.
+if ! project_name_is_valid "$PROJECT_NAME"; then
+  warn_invalid_project_name "$PROJECT_NAME"
+  exit 1
 fi
 
 echo "Project name: '$PROJECT_NAME'"

--- a/update.sh
+++ b/update.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ "$RECONFIGURE" == "true" ]];
 then
-  ./build.sh --name $PROJECT_NAME
+  ./build.sh --name "$PROJECT_NAME"
 fi
 
 echo "Updating deployment..."


### PR DESCRIPTION
## Summary
Add validation for Docker Compose project names to prevent deployment failures caused by invalid characters or formatting. Project names are now validated against Docker Compose's requirements and rejected if they don't conform.

## Key Changes
- **Added project name validation function** (`project_name_is_valid`) that enforces Docker Compose naming rules: lowercase letters, digits, dashes, and underscores only, must start with a letter or digit
- **Enhanced interactive prompt** to re-prompt users when an invalid project name is entered, with clear error messages explaining the requirements
- **Added final validation guard** that catches invalid names from any source (quiet mode, command-line arguments, `.settings` file, or interactive input) and exits with an error before proceeding
- **Improved error messaging** with dedicated `warn_invalid_project_name` function that clearly explains what characters and formats are allowed
- **Fixed shell quoting** in `update.sh` to properly handle project names with special characters when passed to `build.sh`

## Implementation Details
- The validation regex `^[a-z0-9][a-z0-9_-]*$` matches Docker Compose's actual naming constraints
- Interactive prompt uses `while read` loop to allow graceful termination on EOF (Ctrl-D) while re-prompting on invalid input
- Empty user input during interactive prompt preserves the currently proposed name
- Final guard ensures no invalid name can slip through regardless of how it was supplied, preventing broken deployments

https://claude.ai/code/session_013FJedUwyZXeigHXpC4dNhf