### PR TITLE
Add MongoDB memory bounding and single-node replica set

### DIFF
--- a/MONGODB.md
+++ b/MONGODB.md
@@ -1,0 +1,160 @@
+# MongoDB Deployment Notes
+
+This document covers how the main `mongo` service (used by `dbserver` and
+`data_interconnector`) is deployed, why its memory is bounded, and why it runs
+as a **single-node replica set**.
+
+## Background
+
+Deployments previously ran `mongod` with no memory bounds. MongoDB sizes its
+WiredTiger cache to roughly 50% of RAM, and **mongod 4.2 cannot detect
+container (cgroup v2) memory limits**, so it sizes the cache from the *host*
+RAM. Combined with allocator fragmentation (a known issue with the tcmalloc
+bundled in the 4.x series), memory use grows over time until the host OOM
+killer SIGKILLs mongod. An unclean kill discards any writes that were
+acknowledged but not yet journaled/checkpointed, which has caused data loss.
+
+The mitigations are layered:
+
+1. **Bound the WiredTiger cache** (`--wiredTigerCacheSizeGB`) so mongod's main
+   memory consumer has an explicit ceiling.
+2. **Bound the container** (`deploy.resources.limits.memory`) so that even
+   with fragmentation/overhead growth, the kernel kills and docker restarts
+   *only* the mongo container (`restart: always`) instead of the host OOM
+   killer picking arbitrary victims.
+3. **Run as a single-node replica set** so clients can request
+   journal-acknowledged writes, making acknowledged data survive an unclean
+   mongod death (see below).
+
+## Settings
+
+These are prompted by `./build.sh` and stored in `.env`:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `MONGO_MEMORY_LIMIT` | `3g` | Hard memory limit for the mongo container. **Must include units** (e.g. `3g`, `4096m`). |
+| `MONGO_WIREDTIGER_CACHE_GB` | `1` | WiredTiger cache size in GB (fractional values allowed, min `0.25`). |
+| `MONGO_OPLOG_SIZE_MB` | `2048` | Maximum oplog size in MB (replica set write-ahead log, capped collection on disk). |
+
+### Sizing guidance
+
+Use MongoDB's own rule: WiredTiger cache should be at most
+**50% of (memory limit − 1 GB)**. The rest of the budget is used by
+connections, in-memory sorts/aggregations, the oplog and allocator overhead.
+
+| Host RAM | Suggested `MONGO_MEMORY_LIMIT` | Suggested `MONGO_WIREDTIGER_CACHE_GB` |
+| --- | --- | --- |
+| 8 GB | `2g` | `0.5` |
+| 16 GB | `3g` (default) | `1` (default) |
+| 32 GB | `6g` | `2.5` |
+| 64 GB+ | `12g` | `5.5` |
+
+A smaller cache trades query performance for stability; data is never lost by
+shrinking the cache, mongod just reads from disk more often. If the container
+is observed restarting due to the memory limit (`docker inspect mongo`
+shows `OOMKilled: true`), raise `MONGO_MEMORY_LIMIT` rather than the cache.
+
+Host swap also matters: with a container memory limit set, docker allows the
+container to swap by default, which smooths out short spikes instead of
+killing the process. Keep a swap partition/file enabled on database hosts.
+
+## Single-node replica set
+
+The `mongo` service runs with `--replSet rs0`. A replica set with one member
+provides no redundancy, but it changes *durability and capability semantics*:
+
+- **Crash-durable acknowledgements**: replica set members journal writes
+  before acknowledging when clients ask for it (`j: true` / majority write
+  concern). `dbserver` and `data_interconnector` now request
+  journal-acknowledged writes by default, so an acknowledged insert survives
+  an OOM kill or power loss (at worst, mongod replays the journal on restart).
+- **Retryable writes**: drivers can safely retry interrupted writes exactly
+  once (enabled by default in modern pymongo, but only functional against
+  replica sets). This covers the window where mongo is being restarted.
+- **Change streams**: services can subscribe to data changes via the oplog
+  instead of polling. Not used yet, but this unblocks it.
+- **Transactions**: multi-document transactions require a replica set.
+- **Oplog as a recovery aid**: the oplog is an on-disk log of recent writes
+  which can help diagnose/replay recent activity after an incident.
+
+Costs: every write is additionally written to the oplog (bounded by
+`MONGO_OPLOG_SIZE_MB`, default 2 GB of disk) and journal-acknowledged writes
+are slightly slower than fire-and-forget writes. This is the right trade for
+metadata we do not want to lose.
+
+### How initialization works
+
+The replica set is initialized automatically — no manual step is required.
+The mongo container healthcheck:
+
+1. Reports healthy only when the node is `PRIMARY`.
+2. On a fresh (or pre-existing standalone) data volume, `rs.status()` returns
+   `NotYetInitialized` (code 94) and the healthcheck runs `rs.initiate()` with
+   the container's own hostname. The node elects itself PRIMARY within a few
+   seconds.
+3. If the container hostname ever changes (e.g. the `PROJECT_PREFIX` setting
+   changes while reusing the same data volume), the node would come up
+   `REMOVED` (`InvalidReplicaSetConfig`, code 93); the healthcheck self-heals
+   by force-reconfiguring the replica set to the new hostname.
+
+Existing deployments upgrade in place: on the first `./update.sh` with this
+configuration, mongod starts with the existing data files, the healthcheck
+initiates the replica set, and all data remains intact. Expect roughly 10-30
+seconds of write unavailability while the node initiates on first boot;
+`dbserver` and `data_interconnector` already retry their connections.
+
+### Verifying
+
+```bash
+# Replica set state (expect "myState": 1, i.e. PRIMARY)
+docker exec mongo mongo --quiet --eval 'rs.status().myState'
+
+# Effective WiredTiger cache size (bytes)
+docker exec mongo mongo --quiet --eval 'db.serverStatus().wiredTiger.cache["maximum bytes configured"]'
+
+# Container memory usage vs limit
+docker stats --no-stream mongo
+
+# Whether the container has ever been killed by its memory limit
+docker inspect --format '{{.State.OOMKilled}}' mongo
+```
+
+(Prefix the container name with your `PROJECT_PREFIX` if one is set.)
+
+### Rolling back
+
+To return to a standalone mongod: remove `--replSet rs0` and `--oplogSize ...`
+from the `command` and the `healthcheck` block in
+`compose/docker-compose.base.yml`, rebuild (`./build.sh -q`) and re-run
+`./update.sh`. mongod starts fine on the same data volume (the leftover
+replica set config in the `local` database is ignored, and can optionally be
+cleaned by dropping the `local` database). If journal-acknowledged writes are
+kept enabled in the clients they continue to work against a standalone node.
+
+## Related client behaviour
+
+- `scv2_dbserver` connects with `journal=True` (journal-acknowledged writes)
+  and `directConnection=True` by default; both are overridable via the
+  `MONGO_JOURNALED_WRITES` / `MONGO_DIRECT_CONNECTION` env vars.
+- `data_interconnector` (the MQTT → mongo ingest path) does the same via
+  `PF_MONGO_JOURNALED_WRITES` / `PF_MONGO_DIRECT_CONNECTION`.
+- `scv2_realtime` does not talk to mongo directly (it goes through dbserver's
+  HTTP API) and needs no configuration.
+
+`directConnection=True` makes clients talk to the configured host directly
+instead of relying on replica-set topology discovery. This keeps single-node
+behaviour identical to the old standalone behaviour regardless of hostname or
+`PROJECT_PREFIX` changes, and also works for host-based development against a
+port-published mongo.
+
+## Known gaps / future work
+
+- **The `autozone_mongo` (mongo 7.0) and `mongo_exp` (mongo 8.x) services are
+  not yet memory-bounded.** Modern mongod detects cgroup limits and sizes its
+  cache accordingly, so adding a `deploy.resources.limits.memory` to those
+  services is sufficient when needed.
+- The main image is `mongo:4.2.3` (EOL). Newer server versions have a better
+  allocator and native container-awareness, but upgrading requires stepping
+  through major versions (4.2 → 4.4 → 5.0 → ...) with
+  `featureCompatibilityVersion` bumps on every deployed data volume — a
+  separate, carefully staged project.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Notes for deployment
 - `yq` is used for YAML parsing. `build.sh` can run without `yq` but is much faster if it is installed. Installation instructions are available in [YQ.md](YQ.md)
 - CUDA support requires the host system to have specific driver's installed. Instructions for setting up CUDA support are available at [realtime/CUDA.md](https://github.com/pacefactory/scv2_realtime/blob/main/CUDA.md)
 
+## MongoDB
+
+The main `mongo` service runs with a bounded memory footprint and as a single-node replica set. Sizing guidance, how the replica set is initialized, verification and rollback steps are documented in [MONGODB.md](MONGODB.md).
+
 ## Build script
 
 Run the `build.sh` script to enable/disable compose profiles and set environment variables.

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -45,6 +45,15 @@ x-pf-info:
       default: latest
     DATA_INTERCONNECTOR_TAG:
       default: latest
+    MONGO_MEMORY_LIMIT:
+      description: Hard memory limit for the mongo container, with units (e.g. 3g). See MONGODB.md for sizing guidance
+      default: 3g
+    MONGO_WIREDTIGER_CACHE_GB:
+      description: MongoDB WiredTiger cache size in GB. Rule of thumb is 50% of (MONGO_MEMORY_LIMIT - 1GB)
+      default: 1
+    MONGO_OPLOG_SIZE_MB:
+      description: Maximum size (in MB) of the MongoDB replica set oplog
+      default: 2048
     HTTP_PORT:
       default: 80
 
@@ -54,6 +63,59 @@ services:
     hostname: ${PROJECT_PREFIX:-}mongo
     image: mongo:4.2.3-bionic
     restart: always
+    # Memory bounding + single-node replica set (see MONGODB.md for details)
+    # - wiredTigerCacheSizeGB must be set explicitly, since mongod 4.2 cannot
+    #   detect container memory limits and would otherwise size its cache
+    #   from the *host* RAM (unbounded growth -> host OOM killer events)
+    # - replSet/oplogSize run mongo as a single-node replica set, which gives
+    #   journal-acknowledged (crash-durable) writes, retryable writes and
+    #   change streams; the replica set is initialized by the healthcheck below
+    command:
+      - "mongod"
+      - "--quiet"
+      - "--slowms"
+      - "200"
+      - "--wiredTigerCacheSizeGB"
+      - "${MONGO_WIREDTIGER_CACHE_GB:-1}"
+      - "--replSet"
+      - "rs0"
+      - "--oplogSize"
+      - "${MONGO_OPLOG_SIZE_MB:-2048}"
+    # Hard cap so a misbehaving mongod is restarted by docker (restart: always)
+    # instead of growing until the host OOM killer takes out arbitrary processes
+    deploy:
+      resources:
+        limits:
+          memory: ${MONGO_MEMORY_LIMIT:-3g}
+    # The healthcheck reports healthy only when the node is PRIMARY. As a side
+    # effect it initializes the single-node replica set on first boot (code 94,
+    # NotYetInitialized) and re-binds the replica set config if the container
+    # hostname changes, e.g. after a PROJECT_PREFIX change (code 93,
+    # InvalidReplicaSetConfig)
+    healthcheck:
+      test:
+        - "CMD"
+        - "mongo"
+        - "--quiet"
+        - "--eval"
+        - |
+          var self_host = getHostName() + ":27017";
+          var status;
+          try { status = rs.status(); } catch (rs_error) { status = rs_error; }
+          if (status.ok === 1 && status.myState === 1) { quit(0); }
+          if (status.code === 94) {
+            rs.initiate({ _id: "rs0", members: [{ _id: 0, host: self_host }] });
+          } else if (status.code === 93) {
+            var cfg = db.getSiblingDB("local").system.replset.findOne();
+            cfg.members = [{ _id: 0, host: self_host }];
+            cfg.version += 1;
+            db.adminCommand({ replSetReconfig: cfg, force: true });
+          }
+          quit(1);
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     # Increase open file handle limits (https://github.com/pacefactory/deployment-scripts/issues/94)
     ulimits:
       nofile:


### PR DESCRIPTION
## Summary
Implements memory-bounded MongoDB deployment with a single-node replica set to prevent data loss from OOM kills and enable crash-durable writes.

## Key Changes

- **New MONGODB.md documentation**: Comprehensive guide covering the rationale for memory bounding, replica set initialization, sizing guidance, verification steps, and rollback procedures
- **Docker Compose configuration updates**:
  - Added three new configurable settings (`MONGO_MEMORY_LIMIT`, `MONGO_WIREDTIGER_CACHE_GB`, `MONGO_OPLOG_SIZE_MB`) with sensible defaults
  - Configured mongod to run with explicit WiredTiger cache size to prevent unbounded growth on container memory limits
  - Enabled single-node replica set mode (`--replSet rs0`) with configurable oplog size
  - Added hard memory limit via `deploy.resources.limits` to ensure docker restarts the container instead of host OOM killer
  - Implemented automatic replica set initialization and self-healing via healthcheck that:
    - Initializes the replica set on first boot
    - Re-binds the replica set config if container hostname changes (e.g., after `PROJECT_PREFIX` changes)
    - Only reports healthy when the node is PRIMARY
- **Updated README.md**: Added reference to new MONGODB.md documentation

## Implementation Details

The solution uses a layered mitigation approach:
1. Explicit WiredTiger cache size prevents mongod from sizing its cache from host RAM
2. Container memory limit ensures docker restarts only the mongo service on OOM
3. Single-node replica set enables journal-acknowledged writes, making acknowledged data survive unclean mongod deaths

The healthcheck script intelligently handles both fresh deployments and existing data volumes, with automatic recovery from hostname changes. Existing deployments upgrade in place with minimal write unavailability (~10-30 seconds) during initial replica set initialization.

https://claude.ai/code/session_012j6R1Ks9ae3J17Y7Dr4MJg