### PR TITLE
Add PF_TRIM_SEGMENTS_TO_BLOCK configuration option

### DIFF
--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -37,6 +37,9 @@ x-pf-info:
     PF_PROCESS_BLOCK_LAG_MINUTES:
       description: Duration to wait after end of a processing block for late-arriving data to arrive in dbserver (minutes)
       default: 5
+    PF_TRIM_SEGMENTS_TO_BLOCK:
+      description: Trim segments of some entry types (GENERIC_DURATION_FILTER, GENERIC_COMPLEMENT, MAPPED_UNION) to the processing block time range (true/false)
+      default: false
     GIFWRAPPER_TAG:
       default: latest
     DTREESERVER_TAG:
@@ -317,6 +320,7 @@ services:
       - "PF_PROCESS_BLOCK_DURATION_MINUTES=${PF_PROCESS_BLOCK_DURATION_MINUTES:-15}"
       - "PF_PROCESS_BLOCK_PREVIOUS_MINUTES=${PF_PROCESS_BLOCK_PREVIOUS_MINUTES:-5}"
       - "PF_PROCESS_BLOCK_LAG_MINUTES=${PF_PROCESS_BLOCK_LAG_MINUTES:-5}"
+      - "PF_TRIM_SEGMENTS_TO_BLOCK=${PF_TRIM_SEGMENTS_TO_BLOCK:-false}"
     volumes:
       - "audit_processing-data:/home/scv2/volume"
     networks:


### PR DESCRIPTION
## Summary
Add a new configuration option `PF_TRIM_SEGMENTS_TO_BLOCK` to control whether segments of certain entry types should be trimmed to the processing block time range.

## Key Changes
- Added `PF_TRIM_SEGMENTS_TO_BLOCK` to the `x-pf-info` metadata in `docker-compose.base.yml` with description and default value of `false`
- Added the environment variable to the audit-processing service configuration to pass the setting through to the container

## Implementation Details
- The new option applies to entry types: `GENERIC_DURATION_FILTER`, `GENERIC_COMPLEMENT`, and `MAPPED_UNION`
- Defaults to `false` to maintain backward compatibility
- Follows the existing pattern for process block configuration options (`PF_PROCESS_BLOCK_DURATION_MINUTES`, `PF_PROCESS_BLOCK_LAG_MINUTES`, etc.)

https://claude.ai/code/session_01XsaFRdSUuBng9yazTftWRt