### PR TITLE
Clarify HTTPS manual certificate setup and self-signed fallback

### DIFF
--- a/compose/docker-compose.https-no-certbot.yml
+++ b/compose/docker-compose.https-no-certbot.yml
@@ -2,10 +2,14 @@ x-pf-info:
   name: HTTPS (manual, no certbot)
   prompt: Enable HTTPS (via direct SSL)
   description: Use existing HTTPS certificate. No provisioning via certbot.
-    You MUST have already updated ./credentials/ssl/live/${SERVER_NAME}/fullchain.pem and
-    ./credentials/ssl/live/${SERVER_NAME}/privkey.pem with certificate and key.
+    The certificate and key are read from ./credentials/ssl/live/${SERVER_NAME}/fullchain.pem
+    and ./credentials/ssl/live/${SERVER_NAME}/privkey.pem (the paths used by the
+    automated certificate install and scripts/import-ssl-cert.sh).
     If privkey.pem is encrypted, the password must be specified in
     ./credentials/ssl/live/${SERVER_NAME}/privkey.pass on a single line.
+    If the certificate and key do not exist yet, the apigateway serves a
+    temporary self-signed certificate until they are installed and the
+    deployment is restarted (./update.sh).
     The mqtts-public sub-profile (default-enabled) reuses these certs to
     expose MQTTS on port 8883.
   sub-profiles:


### PR DESCRIPTION
## Summary
Updated the documentation in the HTTPS manual certificate profile to better explain certificate path expectations and clarify the self-signed certificate fallback behavior.

## Key Changes
- Reworded certificate path description to indicate these are the standard locations used by automated certificate installation and the import script
- Added clarification that a temporary self-signed certificate is served if the actual certificates don't exist yet, with instructions to restart the deployment after installing certificates
- Improved overall clarity of the setup requirements and runtime behavior

## Implementation Details
The changes are purely documentation updates to the `x-pf-info` section of the HTTPS manual profile compose file. This helps users understand:
1. Where certificates should be placed (standard paths used by other certificate management tools)
2. What happens if certificates aren't present yet (graceful fallback to self-signed)
3. How to complete the setup (install certificates and run `./update.sh`)

https://claude.ai/code/session_01YTJLoiztDCMvirHqTTFNR4