### PR TITLE
Replace PF_TRIM_SEGMENTS_TO_BLOCK with per-entry segment trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ Flags
 - Pass `-q` to skip all user prompts.
 - Pass `--pull` to force-pull all latest images referenced in the compose file.
 
+## Upgrade notes
+
+### Audit processing: per-entry segment trimming (2026-07)
+
+`PF_TRIM_SEGMENTS_TO_BLOCK` has been removed. Segment trimming at processing-block boundaries is
+now controlled **per entry** in the audit config (webgui → Advanced Entry Edit), is ON by default
+for all station entries and most generic entries, and trimmed pieces are stitched back together
+in storage. A stale `PF_TRIM_SEGMENTS_TO_BLOCK` value in an existing `.env` is harmless (nothing
+reads it); re-run `./build.sh` to regenerate the compose without it.
+
+A new setting `PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES` (default 240) caps the per-entry source-data
+lookback that audit processing now derives from each entry's duration parameters.
+
+Segment data stored **before** this upgrade does not self-heal: segments dropped or trimmed under
+the old rules stay as-is until the affected entry is cleared + reprocessed (webgui "Clear entry
+from uistore" button, or the audit-processing service's
+`GET /repair/:camera/:configID/:entryID/by-time-range/:start/:end` route). This applies
+especially to sites that ran with `PF_TRIM_SEGMENTS_TO_BLOCK=true` — their legacy trimmed pieces
+carry no provenance flags and are never stitched.
+
 # Tools
 
 ## Record & Stitch Video

--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ reads it); re-run `./build.sh` to regenerate the compose without it.
 A new setting `PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES` (default 240) caps the per-entry source-data
 lookback that audit processing now derives from each entry's duration parameters.
 
-Segment data stored **before** this upgrade does not self-heal: segments dropped or trimmed under
-the old rules stay as-is until the affected entry is cleared + reprocessed (webgui "Clear entry
-from uistore" button, or the audit-processing service's
-`GET /repair/:camera/:configID/:entryID/by-time-range/:start/:end` route). This applies
-especially to sites that ran with `PF_TRIM_SEGMENTS_TO_BLOCK=true` — their legacy trimmed pieces
-carry no provenance flags and are never stitched.
+Segment data stored **before** this upgrade is deliberately left as-is: segments dropped or
+trimmed under the old rules (including at sites that ran `PF_TRIM_SEGMENTS_TO_BLOCK=true`) carry
+no provenance flags and are never touched by the new stitching. Only blocks processed after the
+upgrade get the new behavior.
 
 # Tools
 

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -37,9 +37,9 @@ x-pf-info:
     PF_PROCESS_BLOCK_LAG_MINUTES:
       description: Duration to wait after end of a processing block for late-arriving data to arrive in dbserver (minutes)
       default: 5
-    PF_TRIM_SEGMENTS_TO_BLOCK:
-      description: Trim segments of some entry types (GENERIC_DURATION_FILTER, GENERIC_COMPLEMENT, MAPPED_UNION) to the processing block time range (true/false)
-      default: false
+    PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES:
+      description: Upper bound on the per-entry source-data lookback derived from duration parameters in each entry's dependency chain (minutes)
+      default: 240
     GIFWRAPPER_TAG:
       default: latest
     DTREESERVER_TAG:
@@ -322,7 +322,7 @@ services:
       - "PF_PROCESS_BLOCK_DURATION_MINUTES=${PF_PROCESS_BLOCK_DURATION_MINUTES:-15}"
       - "PF_PROCESS_BLOCK_PREVIOUS_MINUTES=${PF_PROCESS_BLOCK_PREVIOUS_MINUTES:-5}"
       - "PF_PROCESS_BLOCK_LAG_MINUTES=${PF_PROCESS_BLOCK_LAG_MINUTES:-5}"
-      - "PF_TRIM_SEGMENTS_TO_BLOCK=${PF_TRIM_SEGMENTS_TO_BLOCK:-false}"
+      - "PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES=${PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES:-240}"
     volumes:
       - "audit_processing-data:/home/scv2/volume"
     networks:


### PR DESCRIPTION
## Summary
This change replaces the global `PF_TRIM_SEGMENTS_TO_BLOCK` environment variable with a new per-entry segment trimming system controlled through the audit config UI, along with a new `PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES` setting to cap source-data lookback during audit processing.

## Key Changes
- **Removed** `PF_TRIM_SEGMENTS_TO_BLOCK` environment variable from docker-compose configuration
- **Added** `PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES` (default: 240 minutes) to control the upper bound on per-entry source-data lookback derived from duration parameters
- **Updated** audit processing to support per-entry segment trimming controlled via the webgui Advanced Entry Edit interface (enabled by default for station and most generic entries)
- **Implemented** segment stitching in storage to reassemble trimmed pieces
- **Preserved** backward compatibility: existing segment data is left unchanged; only blocks processed after the upgrade use the new behavior

## Implementation Details
- The new setting is applied at the audit_processing service level in the docker-compose configuration
- Stale `PF_TRIM_SEGMENTS_TO_BLOCK` values in existing `.env` files are harmless and can be removed by re-running `./build.sh`
- Segments dropped or trimmed under the old global rules carry no provenance flags and are never touched by the new stitching logic
- Comprehensive upgrade notes added to README documenting the migration path and behavioral changes

https://claude.ai/code/session_015hUvViFFCGW7AhVgQ1vuYn