### PR TITLE
Gate segment trim/stitch behind PF_ENABLE_SEGMENT_TRIM_STITCH (default false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ reads it); re-run `./build.sh` to regenerate the compose without it.
 A new setting `PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES` (default 240) caps the per-entry source-data
 lookback that audit processing now derives from each entry's duration parameters.
 
+**Global kill switch (2026-07):** the whole trim/stitch/derived-lookback feature is additionally
+gated by `PF_ENABLE_SEGMENT_TRIM_STITCH`, which **defaults to false** pending performance
+evaluation at scale. While false, audit processing behaves exactly as before the feature landed
+(legacy drop rule, fixed fetch windows, no stitch pass) and per-entry trim settings are ignored;
+stored records are never modified by the switch. Set it to `true` to enable the feature.
+
 Segment data stored **before** this upgrade is deliberately left as-is: segments dropped or
 trimmed under the old rules (including at sites that ran `PF_TRIM_SEGMENTS_TO_BLOCK=true`) carry
 no provenance flags and are never touched by the new stitching. Only blocks processed after the

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -40,6 +40,9 @@ x-pf-info:
     PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES:
       description: Upper bound on the per-entry source-data lookback derived from duration parameters in each entry's dependency chain (minutes)
       default: 240
+    PF_ENABLE_SEGMENT_TRIM_STITCH:
+      description: Globally enable per-entry segment trimming, stitching, and derived source-data lookback in audit processing (true/false)
+      default: false
     GIFWRAPPER_TAG:
       default: latest
     DTREESERVER_TAG:
@@ -323,6 +326,7 @@ services:
       - "PF_PROCESS_BLOCK_PREVIOUS_MINUTES=${PF_PROCESS_BLOCK_PREVIOUS_MINUTES:-5}"
       - "PF_PROCESS_BLOCK_LAG_MINUTES=${PF_PROCESS_BLOCK_LAG_MINUTES:-5}"
       - "PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES=${PF_PROCESS_BLOCK_MAX_LOOKBACK_MINUTES:-240}"
+      - "PF_ENABLE_SEGMENT_TRIM_STITCH=${PF_ENABLE_SEGMENT_TRIM_STITCH:-false}"
     volumes:
       - "audit_processing-data:/home/scv2/volume"
     networks:


### PR DESCRIPTION
## Summary

Exposes the audit-processing global kill switch for the per-entry segment trim/stitch/derived-lookback feature (pacefactory/scv3_services_processing#124), **defaulted to disabled** pending performance evaluation at scale.

## Changes

- `compose/docker-compose.base.yml`: new `PF_ENABLE_SEGMENT_TRIM_STITCH` setting (`x-pf-info` metadata + proc service environment entry), default `false`
- `README.md`: upgrade note explaining the kill switch — while `false`, audit processing behaves exactly as before the trimming feature landed (legacy drop rule, fixed fetch windows, no stitch pass), per-entry trim settings are ignored, and stored records are never modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB5zQ2qJWu33RiQEriLpvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB5zQ2qJWu33RiQEriLpvi)_