### PR TITLE
Add WEBGUI_DEFAULT_GHOSTING_TYPE setting to the base profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # PROJECT_PREFIX=
 
 # WEBGUI_FORCE_GHOSTING=true
+# One of: no_image, edges, edges_inverted, ghosted, ghosted_blur, color_invert
+# WEBGUI_DEFAULT_GHOSTING_TYPE=ghosted
 # WEBGUI_RETRIEVE_REALTIME_CAM_CONFIG_ON_INIT=false
 # WEBGUI_OBJ_REQ_BATCH_SIZE=20
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ The platform supports tiered ghosting enforcement to control access to unghosted
 - Comma-separated list of camera names that can be displayed unghosted in the webgui.
 - Only effective when `WEBGUI_FORCE_GHOSTING=true` and `DBSERVER_DISABLE_SNAPSHOT_IMAGES=false` (soft mode).
 
+### WEBGUI_DEFAULT_GHOSTING_TYPE
+
+- **Default:** `ghosted`
+- Ghosting style the webgui starts with. One of `no_image` (Outline), `edges` (Dark Mode),
+  `edges_inverted` (Light Mode), `ghosted` (Ghosted), `ghosted_blur` (Blur), `color_invert` (Invert).
+- Only sets the starting value: users can still pick a different style from the ghosting settings
+  dropdown for their session. Independent of `WEBGUI_FORCE_GHOSTING`, which locks whether ghosting
+  can be turned off at all.
+- An unrecognized value falls back to `ghosted` in the webgui.
+
 ### DBSERVER_DISABLE_SNAPSHOT_IMAGES
 
 - **Default:** `true`

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -20,6 +20,9 @@ x-pf-info:
     WEBGUI_UNGHOSTED_CAMERA_LIST:
       description: List of cameras that should not be ghosted. Should be a comma separated list of camera names
       default: ""
+    WEBGUI_DEFAULT_GHOSTING_TYPE:
+      description: "Ghosting style the webgui starts with. One of: no_image, edges, edges_inverted, ghosted, ghosted_blur, color_invert"
+      default: ghosted
     DBSERVER_DISABLE_SNAPSHOT_IMAGES:
       description: Disable unghosted snapshot image endpoints in dbserver (hard ghosting enforcement)
       default: true
@@ -258,6 +261,7 @@ services:
       - "WEBGUI_APIGATEWAY=true"
       - "WEBGUI_FORCE_GHOSTING=${WEBGUI_FORCE_GHOSTING:-true}"
       - "WEBGUI_UNGHOSTED_CAMERA_LIST=${WEBGUI_UNGHOSTED_CAMERA_LIST:-}"
+      - "WEBGUI_DEFAULT_GHOSTING_TYPE=${WEBGUI_DEFAULT_GHOSTING_TYPE:-ghosted}"
       - "WEBGUI_RETRIEVE_REALTIME_CAM_CONFIG_ON_INIT=${WEBGUI_RETRIEVE_REALTIME_CAM_CONFIG_ON_INIT:-false}"
       - "WEBGUI_OBJ_REQ_BATCH_SIZE=${WEBGUI_OBJ_REQ_BATCH_SIZE:-20}"
       - "WEBGUI_WORK_QUEUE_INSERTION_MODE=${WEBGUI_WORK_QUEUE_INSERTION_MODE:-depth-first}"


### PR DESCRIPTION
## What

Sites that want the audit app to start in a ghosting style other than "Ghosted" (e.g. Blur or Dark Mode) had no way to configure it — every user had to pick it from the webgui's ghosting dropdown on each visit.

This adds `WEBGUI_DEFAULT_GHOSTING_TYPE` to the base profile, following `WEBGUI_FORCE_GHOSTING` exactly: `build.sh` prompts for it, writes it to `.env`, and the value is passed into the `auditgui` container.

Consumed by pacefactory/scv3_webgui#759, which reads it in `src/constants/env` and uses it as the initial `core.ghostedType`.

## Changes

- `compose/docker-compose.base.yml`
  - New `x-pf-info.settings` entry (default `ghosted`), so `load_pf_compose_settings` prompts for it.
  - New `auditgui` environment line: `WEBGUI_DEFAULT_GHOSTING_TYPE=${WEBGUI_DEFAULT_GHOSTING_TYPE:-ghosted}`.
- `README.md` — documented under Ghosting Configuration → Environment Variables.
- `.env.example` — commented example with the accepted values.

## Accepted values

`no_image` (Outline), `edges` (Dark Mode), `edges_inverted` (Light Mode), `ghosted` (Ghosted), `ghosted_blur` (Blur), `color_invert` (Invert). The webgui falls back to `ghosted` on an unrecognized value, so a typo at the prompt degrades gracefully.

## Compatibility

Default is `ghosted`, which is the value the webgui used before, so nothing changes for existing deployments. Existing `.env` files need no edits — the compose-file fallback supplies the default, and an operator who accepts the prompt default writes no new line to `.env`, matching how every other setting behaves.

Independent of `WEBGUI_FORCE_GHOSTING`, which controls whether ghosting can be turned off at all; this only sets the starting style.

## Testing

`docker compose` is unavailable in this environment, so `build.sh` was not run end to end. Verified instead:

- `compose/docker-compose.base.yml` parses, and both the new setting entry and the `auditgui` environment line resolve as intended (the description is quoted because it contains `: `).
- `build.sh`'s `load_pf_compose_settings` was sourced verbatim against a yq stand-in: a value typed at the prompt is written as `WEBGUI_DEFAULT_GHOSTING_TYPE=<value>` to `.env.new`, and a value already present in `.env` is offered as the prompt default and preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx68HDS4YDETRPdU393UVU)_