### PR TITLE
Add health checks for Expresso profile services

### DIFF
--- a/compose/docker-compose.expresso-010.yml
+++ b/compose/docker-compose.expresso-010.yml
@@ -36,6 +36,17 @@ services:
     restart: always
     logging:
       driver: local
+    # Liveness only (/health-check/live never touches mongo or redis), so a dependency
+    # blip cannot flip the container to unhealthy. The start_period covers the startup
+    # migrations in the app's lifespan, which run before uvicorn accepts connections.
+    # /health-check is the dependency-aware report, for monitoring rather than docker.
+    healthcheck:
+      test:
+        ["CMD-SHELL", "wget -qO- http://localhost:8456/health-check/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     volumes:
       - expresso-data:/home/scv2/volume
       # Read-only mount of the dbserver data volume so the stations config UI
@@ -84,11 +95,10 @@ services:
       # remote trainers at startup (idempotent).
       - "PF_REMOTE_TRAINER_URLS=${PF_REMOTE_TRAINER_URLS:-}"
 
+    # The API server does not need the celery worker to serve requests, so the worker is
+    # not listed here — starting it first would only delay the server on a cold boot.
     depends_on:
-      mongo:
-        condition: service_started
-        required: true
-      celery_worker:
+      mongo_exp:
         condition: service_started
         required: true
       redis:
@@ -149,6 +159,11 @@ services:
     image: redis:8.2.1-alpine
     restart: always
     command: redis-server --save 60 1 --loglevel warning
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - expresso_network
 
@@ -218,6 +233,12 @@ services:
     hostname: ${PROJECT_PREFIX:-}mongo_exp
     image: mongodb/mongodb-community-server:8.2.1-ubi8
     restart: always
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks:
       - expresso_network
     volumes:


### PR DESCRIPTION
## Summary

Adds health checks to the Expresso profile. Supersedes #147, which was opened in March against a compose file that has since gained `celery_beat`, the trainer sub-profile and the apigateway wiring.

**Health checks report status only — no `depends_on` condition waits on health, so nothing here slows or blocks a deployment's startup.** Docker runs a container's first probe one full `interval` after start, so a `service_healthy` gate would add ~10s to a cold boot even when Mongo and Redis were ready in one. The checks exist for `docker ps` visibility and monitoring.

- `expresso_server` probes `/health-check/live`, which never touches Mongo or Redis, so a dependency blip cannot flip the container to unhealthy. `start_period: 60s` covers the startup migrations that run in the app's lifespan before uvicorn accepts connections.
- `mongo_exp` gets a `mongosh` ping, `redis` gets `redis-cli ping`.
- `expresso_server` no longer depends on the base profile's `mongo` — a Mongo 4.2 container it does not use — but on `mongo_exp`, which it does. This was a pre-existing bug on `main`: a hard `required: true` dependency on an unrelated service, and none on the Mongo it actually connects to.
- `expresso_server` no longer depends on `celery_worker`. It does not need the worker to serve requests, and starting the worker first only delays a cold boot.

### What is deliberately not here

- **No `celery_worker` health check.** The worker runs `--pool=solo`, so tasks execute in the main thread and remote-control/inspect messages go unanswered while a task holds it. Any `celery inspect ping` check would flap through every long tracking or extraction job. A ping would also import `expresso.tasks` — and so torch, XMem, SAM2 and NVML — into a fresh process on every interval.
- **No `celery_beat` health check**, for now.
- **No `expresso_ui` change**: it already carries a `HEALTHCHECK` in its own image (pacefactory/expresso_ui#168).

Port 8456 is hardcoded in the check rather than read from `${PF_EXPRESSO_PORT}`, because `build.sh` runs `docker compose config`, which would resolve the variable at build time against `.env` (where it is not set) and emit a broken URL. 8456 is also what the rest of the file uses.

## Test plan

- [ ] `./build.sh` with the Expresso profile enabled, and confirm the generated `docker-compose.yml` carries the three health checks
- [ ] `docker compose up -d`, then `docker ps` shows `expresso_server`, `mongo_exp` and `redis` reaching `healthy`
- [ ] Confirm cold-start time is unchanged versus `main`
- [ ] Stop `mongo_exp` and confirm `expresso_server` stays `healthy` (liveness, not readiness) while `/health-check` reports `mongo: unavailable`

## Related

- Needs pacefactory/expresso_server#386 (the `/health-check/live` route) in the deployed `expresso_server` image first — until then the check would fail against a 404.
- Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBuE8CBrpgRzH8t6EMRFP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBuE8CBrpgRzH8t6EMRFP7)_