### PR TITLE
Add UISERVER_AUDIT_DEFAULT_TIMEZONE build setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ This repository contains deployment scripts for containerized services using Doc
 - Environment variables in `.env` file
 - Interactive prompts for profile-specific settings
 - Backup of previous .env as .env.backup
+- `UISERVER_AUDIT_DEFAULT_TIMEZONE` seeds the audit `global.json` `timeZone` when the auditgui
+  container starts. It only fills an unset/empty value: a time zone set in the app always wins,
+  and clearing it in the app lets the setting seed it again on the next restart. Leave it blank
+  to opt out entirely.
 
 ## Commands
 - **Build compose file**: `./build.sh` (Linux) or `./scripts/build-mac.sh` (macOS)

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -23,6 +23,9 @@ x-pf-info:
     WEBGUI_DEFAULT_GHOSTING_TYPE:
       description: "Ghosting style the webgui starts with. One of: no_image, edges, edges_inverted, ghosted, ghosted_blur, color_invert"
       default: ghosted
+    UISERVER_AUDIT_DEFAULT_TIMEZONE:
+      description: "IANA time zone for this site (e.g. America/Toronto). Seeds the audit global.json timeZone when it is not already set; a time zone set in the app always wins"
+      default: ""
     DBSERVER_DISABLE_SNAPSHOT_IMAGES:
       description: Disable unghosted snapshot image endpoints in dbserver (hard ghosting enforcement)
       default: true
@@ -271,6 +274,9 @@ services:
       - "WEBGUI_STATIC_PATH=/scv3/static/"
       - "WEBGUI_BASE_PATH=/scv3"
       - "WEBGUI_SOCIAL_WEB_APP_URL=/"
+      # Seeds the audit global.json timeZone on startup when it is unset; never overrides a
+      # time zone set in the app (see scv3_webgui uiserver/local/lib/audit_timezone.py)
+      - "UISERVER_AUDIT_DEFAULT_TIMEZONE=${UISERVER_AUDIT_DEFAULT_TIMEZONE:-}"
     volumes:
       - "webgui-data:/home/scv2/volume"
     networks:


### PR DESCRIPTION
Original issue https://github.com/pacefactory/scv3_webgui/issues/794

Adds an ENV for settings the `timeZone` in the uiservers global.json.

The variable is passed to the AuditGUI.